### PR TITLE
docs: update README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ User (web login)
 
 1. User logs in with Privy (social or email) and delegates their embedded wallet to the backend
 2. Issue accessToken (JWT) and save it to the CLI
-3. Call `a2a-wallet sign` to request x402 signing
+3. Call `a2a-wallet x402 sign` to request x402 signing
 4. Web app performs EIP-712 signing via the user's wallet and returns a `PaymentPayload`
 
 ## Quick Start
@@ -51,7 +51,17 @@ cp .env.example .env
 pnpm dev
 ```
 
-### Build the CLI
+### Install the CLI
+
+**macOS / Linux**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/planetarium/a2a-x402-wallet/main/scripts/install.sh | sh
+```
+
+**Windows** — Download `a2a-wallet-windows-x64.exe` from the [Releases](https://github.com/planetarium/a2a-x402-wallet/releases/latest) page, rename it to `a2a-wallet.exe`, and place it in a folder on your PATH.
+
+**Build from source** (requires Node.js >= 22)
 
 ```bash
 pnpm --filter a2a-x402-wallet-cli build

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -132,6 +132,12 @@ a2a-wallet
 │   ├── decode             Decode and inspect a SIWE token
 │   ├── verify             Verify token signature and expiration
 │   └── auth               All-in-one: prepare → sign → encode
+├── a2a
+│   ├── card               Fetch and display an agent's AgentCard
+│   ├── send               Send a message to an agent and print the response
+│   ├── stream             Send a message and stream the response via SSE
+│   ├── task               Get the current state of a task
+│   └── cancel             Request cancellation of a running task
 ├── whoami                 Show authenticated user info
 └── update                 Update a2a-wallet to the latest version
 ```
@@ -398,6 +404,74 @@ a2a-wallet whoami [--token <jwt>] [--url <url>] [--json]
 | `--token <jwt>` | One-time token for this request only |
 | `--url <url>` | Web app URL for this request only |
 | `--json` | Output pure JSON to stdout |
+
+### `a2a card`
+
+Fetches and displays an agent's AgentCard from `/.well-known/agent-card.json`.
+
+```bash
+a2a-wallet a2a card <url> [--path <path>] [--json]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--path <path>` | Custom agent card path (default: `/.well-known/agent-card.json`) |
+| `--json` | Output raw JSON (single line) |
+
+### `a2a send`
+
+Sends a message to an A2A agent and prints the full response.
+
+```bash
+a2a-wallet a2a send <url> <message> [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--context-id <id>` | Continue an existing conversation context |
+| `--bearer <token>` | Bearer token for agent authentication |
+| `--json` | Output raw JSON (single line) |
+
+### `a2a stream`
+
+Sends a message to an A2A agent and streams the response via SSE. Text parts are written to stdout as they arrive; other events (task, status-update, artifact-update) are printed as pretty JSON.
+
+```bash
+a2a-wallet a2a stream <url> <message> [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--context-id <id>` | Continue an existing conversation context |
+| `--bearer <token>` | Bearer token for agent authentication |
+| `--json` | Output each event as raw JSON (one line per event) |
+
+### `a2a task`
+
+Retrieves the current state of a task.
+
+```bash
+a2a-wallet a2a task <url> <taskId> [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--history <n>` | Include last N messages from task history (default: `0`) |
+| `--bearer <token>` | Bearer token for agent authentication |
+| `--json` | Output raw JSON (single line) |
+
+### `a2a cancel`
+
+Requests cancellation of a running task.
+
+```bash
+a2a-wallet a2a cancel <url> <taskId> [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--bearer <token>` | Bearer token for agent authentication |
+| `--json` | Output raw JSON (single line) |
 
 ### `update`
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -87,6 +87,33 @@ Completes the device session by exchanging a Privy token for an accessToken.
 
 ---
 
+### `POST /api/sign`
+
+Signs an arbitrary message with the user's embedded wallet (EIP-191 personal_sign).
+
+**Authorization**: accessToken (JWT)
+
+**Request body**:
+```json
+{ "message": "Hello, world!" }
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `message` | Yes | Arbitrary string to sign |
+
+**Response**:
+```json
+{ "signature": "0x..." }
+```
+
+**Errors**:
+- `400` — Missing `message`
+- `401` — Missing or expired token
+- `500` — Signing failed
+
+---
+
 ### `POST /api/auth/token`
 
 Exchanges a Privy auth token for an accessToken (JWT). Requires a delegated embedded wallet.


### PR DESCRIPTION
## Summary

Update README files to reflect the current state of the codebase.

- CLI: add `a2a` subcommand group docs and expand installation instructions
- Web: add `POST /api/sign` endpoint docs
- Fix `a2a-wallet sign` → `a2a-wallet x402 sign` command reference