### PR TITLE
feat(x402): improve x402 payment signing into A2A message flow

### DIFF
--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -30,8 +30,10 @@ export interface X402SignRequestBody {
     asset: string;
     payTo: string;
     maxAmountRequired: string;
+    maxTimeoutSeconds?: number;
+    extra?: Record<string, unknown>;
   };
-  validForSeconds: number;
+  validForSeconds?: number;
 }
 
 const TIMEOUT_MS = 10_000;

--- a/apps/cli/src/commands/a2a/send.ts
+++ b/apps/cli/src/commands/a2a/send.ts
@@ -8,10 +8,23 @@ export function makeSendCommand(): Command {
     .argument('<url>', 'Agent base URL (e.g. https://my-agent.example.com)')
     .argument('<message>', 'Text message to send')
     .option('--context-id <id>', 'Continue an existing conversation context')
+    .option('--task-id <id>', 'Task ID to send message to (for payment or multi-turn)')
+    .option('--metadata <json>', 'JSON metadata to attach to the message (e.g. x402 payment payload)')
     .option('--bearer <token>', 'Bearer token for agent authentication')
     .option('--json', 'Output raw JSON (single line)')
-    .action(async (url: string, message: string, opts: { contextId?: string; bearer?: string; json?: boolean }) => {
+    .action(async (url: string, message: string, opts: { contextId?: string; taskId?: string; metadata?: string; bearer?: string; json?: boolean }) => {
       const factory = buildClientFactory(opts.bearer);
+
+      let parsedMetadata: Record<string, unknown> | undefined;
+      if (opts.metadata) {
+        try {
+          parsedMetadata = JSON.parse(opts.metadata);
+        } catch {
+          console.error('Error: --metadata must be valid JSON');
+          process.exit(1);
+        }
+      }
+
       try {
         const client = await factory.createFromUrl(url);
         const response = await client.sendMessage({
@@ -21,6 +34,8 @@ export function makeSendCommand(): Command {
             role: 'user',
             parts: [{ kind: 'text', text: message }],
             ...(opts.contextId ? { contextId: opts.contextId } : {}),
+            ...(opts.taskId ? { taskId: opts.taskId } : {}),
+            ...(parsedMetadata ? { metadata: parsedMetadata } : {}),
           },
         });
 

--- a/apps/cli/src/commands/x402.ts
+++ b/apps/cli/src/commands/x402.ts
@@ -7,13 +7,22 @@ export function makeX402Command(): Command {
 
   cmd
     .command('sign')
-    .description('Sign x402 PaymentRequirements and output a PaymentPayload')
+    .description(
+      'Sign x402 PaymentRequirements and output a ready-to-use A2A message.metadata object.\n\n' +
+      'The output is a JSON object with two keys:\n' +
+      '  "x402.payment.status": "payment-submitted"\n' +
+      '  "x402.payment.payload": <signed PaymentPayload>\n\n' +
+      'When sending an A2A message to submit payment, set message.metadata to this object:\n' +
+      '  { "taskId": "<task-id>", "role": "user", "parts": [...], "metadata": <this output> }'
+    )
     .requiredOption('--scheme <scheme>', 'Payment scheme (currently only "exact" is supported)')
     .requiredOption('--network <network>', 'Blockchain network (e.g. base, base-sepolia)')
     .requiredOption('--asset <address>', 'ERC-20 token contract address')
     .requiredOption('--pay-to <address>', 'Merchant wallet address')
     .requiredOption('--amount <value>', 'Max payment amount in token smallest unit (e.g. 120000000 for 120 USDC)')
-    .option('--valid-for <seconds>', 'Signature validity in seconds', '3600')
+    .option('--valid-for <seconds>', 'Signature validity window in seconds (sets maxTimeoutSeconds)', '3600')
+    .option('--extra-name <name>', 'EIP-712 domain name from token contract (e.g. "USDC")')
+    .option('--extra-version <version>', 'EIP-712 domain version from token contract (e.g. "2")')
     .option('--token <jwt>', 'JWT for this request only (overrides config)')
     .option('--url <url>', 'Web app URL for this request only (overrides config)')
     .option('--json', 'Output pure JSON to stdout (recommended for Agent/MCP use)')
@@ -24,6 +33,8 @@ export function makeX402Command(): Command {
       payTo: string;
       amount: string;
       validFor: string;
+      extraName?: string;
+      extraVersion?: string;
       token?: string;
       url?: string;
       json?: boolean;
@@ -32,11 +43,16 @@ export function makeX402Command(): Command {
 
       if (!cfg.token) exitNotLoggedIn();
 
-      const validForSeconds = parseInt(opts.validFor, 10);
-      if (isNaN(validForSeconds) || validForSeconds <= 0) {
+      const maxTimeoutSeconds = parseInt(opts.validFor, 10);
+      if (isNaN(maxTimeoutSeconds) || maxTimeoutSeconds <= 0) {
         console.error('Error: --valid-for must be a positive integer (seconds)');
         process.exit(1);
       }
+
+      const extra: Record<string, unknown> | undefined =
+        opts.extraName || opts.extraVersion
+          ? { name: opts.extraName, version: opts.extraVersion }
+          : undefined;
 
       try {
         const result = await callX402Sign(cfg.url, cfg.token, {
@@ -46,14 +62,20 @@ export function makeX402Command(): Command {
             asset: opts.asset,
             payTo: opts.payTo,
             maxAmountRequired: opts.amount,
+            maxTimeoutSeconds,
+            ...(extra && { extra }),
           },
-          validForSeconds,
         });
 
+        const metadata = {
+          'x402.payment.status': 'payment-submitted',
+          'x402.payment.payload': result,
+        };
+
         if (opts.json) {
-          console.log(JSON.stringify(result));
+          console.log(JSON.stringify(metadata));
         } else {
-          console.log(JSON.stringify(result, null, 2));
+          console.log(JSON.stringify(metadata, null, 2));
         }
       } catch (err) {
         console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);

--- a/apps/web/src/app/api/x402/sign/route.ts
+++ b/apps/web/src/app/api/x402/sign/route.ts
@@ -67,7 +67,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'paymentRequirements is required' }, { status: 400 });
   }
 
-  const { scheme, network, asset, payTo, maxAmountRequired } = paymentRequirements;
+  const { scheme, network, asset, payTo, maxAmountRequired, maxTimeoutSeconds, extra } = paymentRequirements;
 
   if (!scheme || !network || !asset || !payTo || !maxAmountRequired) {
     return NextResponse.json(
@@ -105,20 +105,28 @@ export async function POST(req: NextRequest) {
 
   // Build ERC-3009 authorization object
   const now = Math.floor(Date.now() / 1000);
+  const validSeconds = maxTimeoutSeconds ?? validForSeconds;
   const authorization: TransferWithAuthorizationPayload = {
     from: fromAddress,
     to: payTo,
     value: maxAmountRequired,
-    validAfter: '0',
-    validBefore: String(now + validForSeconds),
+    validAfter: String(now - 600),
+    validBefore: String(now + validSeconds),
     nonce: generateNonce(),
   };
 
+  // Prefer EIP-712 domain metadata from extra field; fall back to hardcoded token registry
   let tokenMeta: { name: string; version: string };
-  try {
-    tokenMeta = getTokenMetadata(asset);
-  } catch (err) {
-    return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 400 });
+  const extraName = typeof extra?.['name'] === 'string' ? extra['name'] : undefined;
+  const extraVersion = typeof extra?.['version'] === 'string' ? extra['version'] : undefined;
+  if (extraName && extraVersion) {
+    tokenMeta = { name: extraName, version: extraVersion };
+  } else {
+    try {
+      tokenMeta = getTokenMetadata(asset);
+    } catch (err) {
+      return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 400 });
+    }
   }
 
   const typedData = buildTransferWithAuthorizationTypedData(

--- a/apps/web/src/components/install-section.tsx
+++ b/apps/web/src/components/install-section.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { CopyButton } from './ui';
 
 const platforms = ['macOS / Linux', 'Windows', 'Source'] as const;
@@ -158,13 +158,13 @@ function WindowsGuide() {
 }
 
 export function InstallSection() {
-  const [active, setActive] = useState<Platform>('macOS / Linux');
-
-  useEffect(() => {
-    if (navigator.userAgent.toLowerCase().includes('win')) {
-      setActive('Windows');
-    }
-  }, []);
+  // Initializer function avoids calling setState inside useEffect (react-hooks/set-state-in-effect).
+  // typeof navigator guard is required for SSR (navigator is not available server-side).
+  const [active, setActive] = useState<Platform>(() =>
+    typeof navigator !== 'undefined' && navigator.userAgent.toLowerCase().includes('win')
+      ? 'Windows'
+      : 'macOS / Linux'
+  );
 
   return (
     <div className="w-full max-w-2xl">

--- a/packages/x402/src/index.ts
+++ b/packages/x402/src/index.ts
@@ -6,6 +6,7 @@ export interface PaymentRequirements {
   asset: `0x${string}`;
   payTo: `0x${string}`;
   maxAmountRequired: string;
+  maxTimeoutSeconds?: number;
   resource?: string;
   description?: string;
   mimeType?: string;


### PR DESCRIPTION
## Summary

- `x402 sign` now outputs a ready-to-use `message.metadata` object (`x402.payment.status` + `x402.payment.payload`) instead of a raw payload
- Added `--extra-name` / `--extra-version` options to pass EIP-712 domain metadata without relying on the hardcoded token registry
- Added `maxTimeoutSeconds` field to `PaymentRequirements`; sign API now uses it with a clock-skew tolerance on `validAfter`
- Added `--task-id` and `--metadata` options to `a2a send` for attaching payment payloads to A2A messages
- Fixed `setState`-in-effect lint error in `InstallSection` by using a `useState` initializer function

## How to use

```bash
# 1. Sign payment requirements
x402-wallet x402 sign \
  --scheme exact --network base-sepolia \
  --asset 0x... --pay-to 0x... --amount 120000000 \
  --extra-name "USD Coin" --extra-version "2" --json

# 2. Send payment to agent
x402-wallet a2a send <url> "pay" \
  --task-id <task-id> \
  --metadata '<output from step 1>'