### PR TITLE
feat(cli): add agent skills

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -114,31 +114,33 @@ On success, a `PaymentPayload` JSON is printed to stdout.
 
 ```
 a2a-wallet
+├── a2a
+│   ├── card               Fetch and display an agent's AgentCard
+│   ├── send               Send a message to an agent and print the response
+│   ├── stream             Send a message and stream the response via SSE
+│   ├── tasks              Get the current state of a task
+│   └── cancel             Request cancellation of a running task
+├── x402
+│   └── sign               Sign x402 PaymentRequirements → PaymentPayload
 ├── auth
 │   ├── login              Log in via browser callback (humans)
 │   ├── device
 │   │   ├── start          Start device session and print login URL (agent step 1)
 │   │   └── poll           Poll for login completion and save token (agent step 2)
 │   └── logout             Remove the saved token
-├── config
-│   ├── set <key> <value>  Set a config value (token, url)
-│   └── get [key]          Show config values
-├── sign                   Sign an arbitrary message with your wallet
-├── x402
-│   └── sign               Sign x402 PaymentRequirements → PaymentPayload
 ├── siwe
 │   ├── prepare            Generate an EIP-4361 SIWE message
 │   ├── encode             Encode message + signature into a base64url token
 │   ├── decode             Decode and inspect a SIWE token
 │   ├── verify             Verify token signature and expiration
 │   └── auth               All-in-one: prepare → sign → encode
-├── a2a
-│   ├── card               Fetch and display an agent's AgentCard
-│   ├── send               Send a message to an agent and print the response
-│   ├── stream             Send a message and stream the response via SSE
-│   ├── task               Get the current state of a task
-│   └── cancel             Request cancellation of a running task
+├── config
+│   ├── set <key> <value>  Set a config value (token, url)
+│   └── get [key]          Show config values
 ├── whoami                 Show authenticated user info
+├── balance                Show wallet balance
+├── sign                   Sign an arbitrary message with your wallet
+├── faucet                 Request testnet tokens
 └── update                 Update a2a-wallet to the latest version
 ```
 
@@ -501,6 +503,20 @@ a2a-wallet update
 | `ethereum` | 1 |
 | `optimism` | 10 |
 | `arbitrum` | 42161 |
+
+## Agent Skill
+
+A ready-made Agent Skill is bundled in `skills/a2a-wallet/`. Install it once and any compatible agent will automatically know how to use `a2a-wallet` — the right commands, flags, and workflows — without requiring manual explanation.
+
+```bash
+# macOS / Linux
+cp -r skills/a2a-wallet ~/.agents/skills/
+
+# Windows (PowerShell)
+Copy-Item -Recurse skills\a2a-wallet $env:USERPROFILE\.agents\skills\
+```
+
+The skill file follows a standard YAML frontmatter + Markdown format and can be loaded by any agent runtime that supports this convention.
 
 ## Using as an Agent Tool
 

--- a/apps/cli/skills/a2a-wallet/INSTALL.md
+++ b/apps/cli/skills/a2a-wallet/INSTALL.md
@@ -1,0 +1,38 @@
+# a2a-wallet Installation Guide
+
+## macOS / Linux
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/planetarium/a2a-x402-wallet/main/scripts/install.sh | sh
+```
+
+Supported platforms: macOS (Apple Silicon, Intel), Linux (x64, arm64).
+
+## Windows
+
+Download `a2a-wallet-windows-x64.exe` from the [Releases](https://github.com/planetarium/a2a-x402-wallet/releases/latest) page, rename it to `a2a-wallet.exe`, and place it in a folder on your PATH.
+
+## Verify
+
+```bash
+a2a-wallet --version
+```
+
+## First-time login
+
+After installation, authenticate with your wallet:
+
+```bash
+a2a-wallet auth login
+```
+
+For headless / agent environments, use the two-step device flow:
+
+```bash
+# Step 1: get the login URL
+a2a-wallet auth device start --json
+# → {"nonce":"abc123","loginUrl":"https://..."}
+
+# Step 2: show the URL to the user, then poll for completion
+a2a-wallet auth device poll --nonce abc123
+```

--- a/apps/cli/skills/a2a-wallet/SKILL.md
+++ b/apps/cli/skills/a2a-wallet/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: a2a-wallet
+description: >
+  Use the a2a-wallet CLI to interact with A2A agents — send messages, stream responses,
+  and manage tasks. Also supports x402 payment signing and SIWE authentication required
+  by A2A agents. Trigger when the user needs to: send a message to an A2A agent, sign
+  an x402 payment, authenticate via SIWE, log in or out of a2a-wallet, check their
+  wallet address or balance, or configure the a2a-wallet CLI.
+---
+
+# a2a-wallet Skill
+
+## Before you start
+
+Check that `a2a-wallet` is available:
+
+```bash
+a2a-wallet --version
+```
+
+If the command is not found, refer to **[INSTALL.md](./INSTALL.md)** in this directory and guide the user through installation before proceeding. Do not attempt to run any `a2a-wallet` commands until installation is confirmed.
+
+---
+
+Use `a2a-wallet --help` or `a2a-wallet <command> --help` to discover options at any time.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `a2a` | Interact with A2A agents (`card`, `send`, `stream`, `tasks`, `cancel`) |
+| `x402 sign` | Sign x402 PaymentRequirements → PaymentPayload (for paywalled agents) |
+| `siwe` | SIWE token operations (`prepare`, `encode`, `decode`, `verify`, `auth`) |
+| `auth` | Log in / out (`login`, `device start/poll`, `logout`) |
+| `config` | Get or set config values (`token`, `url`) |
+| `whoami` | Show authenticated user info |
+| `balance` | Show wallet balance |
+| `sign` | Sign an arbitrary message with the wallet |
+| `faucet` | Request testnet tokens |
+| `update` | Update the CLI binary |
+
+## Agent Card Extensions
+
+Before interacting with an A2A agent, inspect its card to check which extensions are declared:
+
+```bash
+a2a-wallet a2a card https://my-agent.example.com
+```
+
+The `capabilities.extensions` array in the card lists supported (and possibly required) extensions. Two extensions are relevant to this CLI:
+
+---
+
+### x402 Payments Extension
+
+**Extension URI**: `https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2`
+
+Agents declaring this extension monetize their services via on-chain cryptocurrency payments. If `required: true`, the client **must** implement the x402 flow.
+
+**How to detect**: The agent card will contain:
+
+```json
+{
+  "capabilities": {
+    "extensions": [
+      {
+        "uri": "https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2",
+        "required": true
+      }
+    ]
+  }
+}
+```
+
+**Payment flow**:
+1. Send a message → agent replies with `task.status = input-required` and `metadata["x402.payment.status"] = "payment-required"` plus `metadata["x402.payment.required"]` containing `PaymentRequirements`
+2. Sign the requirements with `x402 sign`:
+   ```bash
+   METADATA=$(a2a-wallet x402 sign \
+     --scheme exact \
+     --network base \
+     --asset <token-address> \
+     --pay-to <merchant-address> \
+     --amount <amount> \
+     --json)
+   ```
+3. Submit payment by sending back with `--task-id` and `--metadata`:
+   ```bash
+   a2a-wallet a2a send \
+     --task-id <task-id> \
+     --metadata "$METADATA" \
+     https://my-agent.example.com "Payment submitted"
+   ```
+
+---
+
+### SIWE Bearer Auth Extension
+
+**Extension URI**: `https://github.com/planetarium/a2a-x402-wallet/tree/main/docs/siwe-bearer-auth/v0.1`
+
+Agents declaring this extension require a wallet-signed auth token on every request. If `required: true`, messages cannot be sent without one.
+
+**How to detect**: The agent card will contain:
+
+```json
+{
+  "extensions": [
+    {
+      "uri": "https://github.com/planetarium/a2a-x402-wallet/tree/main/docs/siwe-bearer-auth/v0.1",
+      "required": true
+    }
+  ]
+}
+```
+
+**Usage**:
+1. Generate a token for the agent's domain:
+   ```bash
+   TOKEN=$(a2a-wallet siwe auth \
+     --domain my-agent.example.com \
+     --uri    https://my-agent.example.com \
+     --ttl    1h \
+     --json | jq -r '.token')
+   ```
+2. Pass it via `--bearer` when sending messages:
+   ```bash
+   a2a-wallet a2a send   --bearer "$TOKEN" https://my-agent.example.com "Hello"
+   a2a-wallet a2a stream --bearer "$TOKEN" https://my-agent.example.com "Hello"
+   ```
+
+**Note**: The token is tied to the agent's domain — a token issued for one agent will be rejected by another.
+
+---
+
+## Agent usage tips
+
+- Use `--json` for machine-readable output
+- Errors → stderr, exit `0` = success, `1` = failure
+- Override token/URL per-call with `--token` / `--url`, or set `A2A_WALLET_TOKEN` env var
+- The CLI detects expired tokens before making network requests and prints guidance
+- Always run `a2a card <url>` first to check which extensions are required before sending messages

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -18,16 +18,16 @@ const program = new Command()
   .description('CLI for signing x402 payment payloads via a2a-wallet')
   .version(pkg.version);
 
-program.addCommand(makeAuthCommand());
-program.addCommand(makeConfigCommand());
-program.addCommand(makeSignCommand());
-program.addCommand(makeX402Command());
-program.addCommand(makeWhoamiCommand());
-program.addCommand(makeUpdateCommand());
 program.addCommand(makeA2ACommand());
+program.addCommand(makeX402Command());
+program.addCommand(makeAuthCommand());
 program.addCommand(makeSiweCommand());
+program.addCommand(makeConfigCommand());
+program.addCommand(makeWhoamiCommand());
 program.addCommand(makeBalanceCommand());
+program.addCommand(makeSignCommand());
 program.addCommand(makeFaucetCommand());
+program.addCommand(makeUpdateCommand());
 
 program.parseAsync(process.argv).catch((err) => {
   console.error(err);


### PR DESCRIPTION
## Summary
Bundles a ready-made Agent Skill (`skills/a2a-wallet/`) so any compatible
agent runtime can automatically understand how to use `a2a-wallet` without
manual explanation.
## Changes
- **`skills/a2a-wallet/SKILL.md`** — Agent skill file with YAML frontmatter
  and full usage guide: commands, x402 payment flow, SIWE bearer auth flow,
  and agent usage tips
- **`skills/a2a-wallet/INSTALL.md`** — Installation guide for macOS/Linux/
  Windows and first-time login (including headless device flow)
- **`README.md`** — Add "Agent Skill" section documenting install path
  (`~/.agents/skills/`) and fix `task` → `tasks` subcommand name in the
  command tree
- **`src/index.ts`** — Reorder command registration to match help output
  order (`a2a`, `x402`, `auth`, `siwe`, `config`, `whoami`, `balance`,
  `sign`, `faucet`, `update`)