### PR TITLE
docs: update skill install path and remove license field

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install -g ./apps/cli
 ### Install the Agent Skill
 
 ```bash
-npx skills add planetarium/a2a-x402-wallet/a2a-wallet
+npx skills add planetarium/a2a-x402-wallet
 ```
 
 Supports Claude Code, Cursor, GitHub Copilot, Gemini CLI, and any [Agent Skills](https://agentskills.io)-compatible runtime.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -506,11 +506,11 @@ a2a-wallet update
 
 ## Agent Skill
 
-A ready-made Agent Skill is published on [skills.sh](https://skills.sh/planetarium/a2a-x402-wallet/a2a-wallet). Install it once and any compatible agent will automatically know how to use `a2a-wallet` — the right commands, flags, and workflows — without requiring manual explanation.
+A ready-made Agent Skill is published on [skills.sh](https://skills.sh/planetarium/a2a-x402-wallet). Install it once and any compatible agent will automatically know how to use `a2a-wallet` — the right commands, flags, and workflows — without requiring manual explanation.
 
 ```bash
 # Via npx (recommended — works with Claude Code, Cursor, GitHub Copilot, Gemini CLI, and more)
-npx skills add planetarium/a2a-x402-wallet/a2a-wallet
+npx skills add planetarium/a2a-x402-wallet
 
 # Manual copy
 cp -r skills/a2a-wallet ~/.agents/skills/          # macOS / Linux (from repo root)

--- a/skills/a2a-wallet/SKILL.md
+++ b/skills/a2a-wallet/SKILL.md
@@ -6,7 +6,6 @@ description: >
   by A2A agents. Trigger when the user needs to: send a message to an A2A agent, sign
   an x402 payment, authenticate via SIWE, log in or out of a2a-wallet, check their
   wallet address or balance, or configure the a2a-wallet CLI.
-license: Apache-2.0
 compatibility: >
   Requires a2a-wallet CLI to be installed. macOS (Apple Silicon, Intel),
   Linux (x64, arm64), Windows (x64). See INSTALL.md for setup instructions.


### PR DESCRIPTION
- Shorten skills.sh install path from
  planetarium/a2a-x402-wallet/a2a-wallet to
  planetarium/a2a-x402-wallet in README and CLI docs
- Remove license field from SKILL.md frontmatter