### PR TITLE
fix(cli): activate x402 extension header based on agent card

### DIFF
--- a/apps/cli/src/commands/a2a/client.ts
+++ b/apps/cli/src/commands/a2a/client.ts
@@ -1,4 +1,16 @@
-import { ClientFactory, ClientFactoryOptions, JsonRpcTransportFactory, RestTransportFactory } from '@a2a-js/sdk/client';
+import type { AgentCard } from '@a2a-js/sdk';
+import {
+  AgentCardResolver,
+  ClientFactory,
+  ClientFactoryOptions,
+  JsonRpcTransportFactory,
+  RestTransportFactory,
+  ServiceParameters,
+  withA2AExtensions,
+} from '@a2a-js/sdk/client';
+import type { Client, RequestOptions } from '@a2a-js/sdk/client';
+
+const X402_EXTENSION_URI = 'https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2';
 
 /**
  * Build a ClientFactory with an optional Bearer token injected into every request.
@@ -20,6 +32,32 @@ export function buildClientFactory(bearer?: string): ClientFactory {
   });
 
   return new ClientFactory(options);
+}
+
+/**
+ * Resolve the agent card, create a client, and build x402 request options if applicable.
+ */
+export async function createClientWithX402(factory: ClientFactory, url: string): Promise<{
+  client: Client;
+  requestOptions: RequestOptions | undefined;
+}> {
+  const card = await AgentCardResolver.default.resolve(url);
+  const client = await factory.createFromAgentCard(card);
+  const requestOptions = buildX402RequestOptions(card);
+  return { client, requestOptions };
+}
+
+function buildX402RequestOptions(card: AgentCard): RequestOptions | undefined {
+  const extensions = card.capabilities?.extensions ?? [];
+  const hasX402 = extensions.some((ext) => ext.uri === X402_EXTENSION_URI);
+
+  if (!hasX402) return undefined;
+
+  return {
+    serviceParameters: ServiceParameters.create(
+      withA2AExtensions(X402_EXTENSION_URI),
+    ),
+  };
 }
 
 /**

--- a/apps/cli/src/commands/a2a/send.ts
+++ b/apps/cli/src/commands/a2a/send.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { randomUUID } from 'crypto';
-import { buildClientFactory, formatA2AError } from './client.js';
+import { buildClientFactory, createClientWithX402, formatA2AError } from './client.js';
 
 export function makeSendCommand(): Command {
   return new Command('send')
@@ -26,7 +26,8 @@ export function makeSendCommand(): Command {
       }
 
       try {
-        const client = await factory.createFromUrl(url);
+        const { client, requestOptions } = await createClientWithX402(factory, url);
+
         const response = await client.sendMessage({
           message: {
             kind: 'message',
@@ -37,7 +38,7 @@ export function makeSendCommand(): Command {
             ...(opts.taskId ? { taskId: opts.taskId } : {}),
             ...(parsedMetadata ? { metadata: parsedMetadata } : {}),
           },
-        });
+        }, requestOptions);
 
         if (opts.json) {
           console.log(JSON.stringify(response));

--- a/apps/cli/src/commands/a2a/stream.ts
+++ b/apps/cli/src/commands/a2a/stream.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { randomUUID } from 'crypto';
-import { buildClientFactory, formatA2AError } from './client.js';
+import { buildClientFactory, createClientWithX402, formatA2AError } from './client.js';
 
 export function makeStreamCommand(): Command {
   return new Command('stream')
@@ -13,7 +13,8 @@ export function makeStreamCommand(): Command {
     .action(async (url: string, message: string, opts: { contextId?: string; bearer?: string; json?: boolean }) => {
       const factory = buildClientFactory(opts.bearer);
       try {
-        const client = await factory.createFromUrl(url);
+        const { client, requestOptions } = await createClientWithX402(factory, url);
+
         const stream = client.sendMessageStream({
           message: {
             kind: 'message',
@@ -22,7 +23,7 @@ export function makeStreamCommand(): Command {
             parts: [{ kind: 'text', text: message }],
             ...(opts.contextId ? { contextId: opts.contextId } : {}),
           },
-        });
+        }, requestOptions);
 
         for await (const event of stream) {
           if (opts.json) {


### PR DESCRIPTION
## Summary

- CLI `a2a send` and `a2a stream` commands now include the `X-A2A-Extensions` header when the target agent's card declares the x402 extension
- Uses SDK's `withA2AExtensions` + `ServiceParameters` API (not custom fetch hacking)
- Agent card is resolved first via `AgentCardResolver.default` singleton, then checked for x402 URI in `capabilities.extensions`
- Extracted `createClientWithX402()` helper in `client.ts` to avoid duplication between send and stream commands

## Context

Per [x402 spec Section 8](https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2), clients MUST request activation of the x402 extension by including its URI in the `X-A2A-Extensions` HTTP header. Without this header, x402-enabled agents reject requests with `-32600: This agent requires the x402 payment extension`.

## Test plan

- [ ] `a2a-wallet a2a send --bearer <token> <x402-agent-url> "hello"` should receive payment-required response instead of extension error
- [ ] `a2a-wallet a2a send --bearer <token> <non-x402-agent-url> "hello"` should work as before (no extension header sent)
- [ ] `a2a-wallet a2a stream` should behave the same as send

🤖 Generated with [Claude Code](https://claude.com/claude-code)