### PR TITLE
feat(a2a/client): always send X-A2A-Extensions header

### DIFF
--- a/apps/cli/src/commands/a2a/client.ts
+++ b/apps/cli/src/commands/a2a/client.ts
@@ -1,21 +1,33 @@
 import { ClientFactory, ClientFactoryOptions, JsonRpcTransportFactory, RestTransportFactory } from '@a2a-js/sdk/client';
 
+const X402_EXTENSION_URI = 'https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2';
+
 /**
  * Build a ClientFactory with an optional Bearer token injected into every request.
+ * Always includes the X-A2A-Extensions header per the x402 spec (Section 8).
  */
 export function buildClientFactory(bearer?: string): ClientFactory {
-  if (!bearer) return new ClientFactory();
-
-  const authFetch: typeof fetch = (input, init) => {
+  const baseFetch: typeof fetch = (input, init) => {
     const headers = new Headers(init?.headers);
-    headers.set('Authorization', `Bearer ${bearer}`);
+    headers.set('X-A2A-Extensions', X402_EXTENSION_URI);
+    if (bearer) headers.set('Authorization', `Bearer ${bearer}`);
     return fetch(input, { ...init, headers });
   };
 
+  if (!bearer) {
+    const options = ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
+      transports: [
+        new JsonRpcTransportFactory({ fetchImpl: baseFetch }),
+        new RestTransportFactory({ fetchImpl: baseFetch }),
+      ],
+    });
+    return new ClientFactory(options);
+  }
+
   const options = ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
     transports: [
-      new JsonRpcTransportFactory({ fetchImpl: authFetch }),
-      new RestTransportFactory({ fetchImpl: authFetch }),
+      new JsonRpcTransportFactory({ fetchImpl: baseFetch }),
+      new RestTransportFactory({ fetchImpl: baseFetch }),
     ],
   });
 


### PR DESCRIPTION
Add X402_EXTENSION_URI constant and inject X-A2A-Extensions
header on every request, with or without a Bearer token,
per x402 spec Section 8.