### PR TITLE
feat(cli)!: make --extra-name/version required and update docs (#25, #26)

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -105,7 +105,9 @@ a2a-wallet x402 sign \
   --network base \
   --asset 0x833589fCD6eDb6E08f4c7C32D4f71b54bda02913 \
   --pay-to 0xMerchantAddress \
-  --amount 120000000
+  --amount 120000000 \
+  --extra-name USDC \
+  --extra-version 2
 ```
 
 On success, a `PaymentPayload` JSON is printed to stdout.
@@ -244,6 +246,8 @@ a2a-wallet x402 sign [options]
 | `--asset <address>` | ERC-20 token contract address |
 | `--pay-to <address>` | Merchant wallet address |
 | `--amount <value>` | Max payment amount in token's smallest unit |
+| `--extra-name <name>` | EIP-712 domain name from token contract (e.g. `"USDC"`) |
+| `--extra-version <version>` | EIP-712 domain version from token contract (e.g. `"2"`) |
 
 **Optional**
 
@@ -556,6 +560,8 @@ A2A_WALLET_TOKEN=<jwt> a2a-wallet x402 sign \
   --asset 0x833589fCD6eDb6E08f4c7C32D4f71b54bda02913 \
   --pay-to 0xMerchantAddress \
   --amount 120000000 \
+  --extra-name USDC \
+  --extra-version 2 \
   --json
 ```
 

--- a/apps/cli/src/commands/x402.ts
+++ b/apps/cli/src/commands/x402.ts
@@ -20,9 +20,9 @@ export function makeX402Command(): Command {
     .requiredOption('--asset <address>', 'ERC-20 token contract address')
     .requiredOption('--pay-to <address>', 'Merchant wallet address')
     .requiredOption('--amount <value>', 'Max payment amount in token smallest unit (e.g. 120000000 for 120 USDC)')
+    .requiredOption('--extra-name <name>', 'EIP-712 domain name from token contract (e.g. "USDC")')
+    .requiredOption('--extra-version <version>', 'EIP-712 domain version from token contract (e.g. "2")')
     .option('--valid-for <seconds>', 'Signature validity window in seconds (sets maxTimeoutSeconds)', '3600')
-    .option('--extra-name <name>', 'EIP-712 domain name from token contract (e.g. "USDC")')
-    .option('--extra-version <version>', 'EIP-712 domain version from token contract (e.g. "2")')
     .option('--token <jwt>', 'JWT for this request only (overrides config)')
     .option('--url <url>', 'Web app URL for this request only (overrides config)')
     .option('--json', 'Output pure JSON to stdout (recommended for Agent/MCP use)')
@@ -32,9 +32,9 @@ export function makeX402Command(): Command {
       asset: string;
       payTo: string;
       amount: string;
+      extraName: string;
+      extraVersion: string;
       validFor: string;
-      extraName?: string;
-      extraVersion?: string;
       token?: string;
       url?: string;
       json?: boolean;
@@ -49,11 +49,6 @@ export function makeX402Command(): Command {
         process.exit(1);
       }
 
-      const extra: Record<string, unknown> | undefined =
-        opts.extraName || opts.extraVersion
-          ? { name: opts.extraName, version: opts.extraVersion }
-          : undefined;
-
       try {
         const result = await callX402Sign(cfg.url, cfg.token, {
           paymentRequirements: {
@@ -63,7 +58,10 @@ export function makeX402Command(): Command {
             payTo: opts.payTo,
             maxAmountRequired: opts.amount,
             maxTimeoutSeconds,
-            ...(extra && { extra }),
+            extra: {
+              name: opts.extraName,
+              version: opts.extraVersion,
+            },
           },
         });
 

--- a/skills/a2a-wallet/SKILL.md
+++ b/skills/a2a-wallet/SKILL.md
@@ -16,19 +16,7 @@ metadata:
 
 # a2a-wallet Skill
 
-## Before you start
-
-Check that `a2a-wallet` is available:
-
-```bash
-a2a-wallet --version
-```
-
-If the command is not found, refer to **[INSTALL.md](./INSTALL.md)** in this directory and guide the user through installation before proceeding. Do not attempt to run any `a2a-wallet` commands until installation is confirmed.
-
----
-
-Use `a2a-wallet --help` or `a2a-wallet <command> --help` to discover options at any time.
+If a command fails with a "command not found" error, refer to **[INSTALL.md](./INSTALL.md)** in this directory and guide the user through installation.
 
 ## Commands
 
@@ -88,6 +76,8 @@ Agents declaring this extension monetize their services via on-chain cryptocurre
      --asset <token-address> \
      --pay-to <merchant-address> \
      --amount <amount> \
+     --extra-name <eip712-domain-name> \
+     --extra-version <eip712-domain-version> \
      --json)
    ```
 3. Submit payment by sending back with `--task-id` and `--metadata`:
@@ -145,3 +135,4 @@ Agents declaring this extension require a wallet-signed auth token on every requ
 - Override token/URL per-call with `--token` / `--url`, or set `A2A_WALLET_TOKEN` env var
 - The CLI detects expired tokens before making network requests and prints guidance
 - Always run `a2a card <url>` first to check which extensions are required before sending messages
+- Use `a2a-wallet --help` or `a2a-wallet <command> --help` to discover options at any time


### PR DESCRIPTION
## Summary

- **#25** Make `--extra-name` and `--extra-version` required options in `x402 sign`
  - Changed `.option()` → `.requiredOption()` for both flags
  - Updated TypeScript types from `string | undefined` to `string`
  - Simplified `extra` object construction (removed conditional undefined logic)
  - Updated all `x402 sign` examples in `apps/cli/README.md` and `skills/a2a-wallet/SKILL.md`

- **#26** Remove upfront install check from `SKILL.md`, adopt lazy detection
  - Removed `## Before you start` section (proactive `--version` check)
  - Agent now attempts the command directly; guides to `INSTALL.md` only on `command not found`
  - Moved `--help` tip to `## Agent usage tips` (lower priority)

## Breaking Change

`a2a-wallet x402 sign` now **requires** `--extra-name` and `--extra-version`.
Existing scripts omitting these flags will error with a missing required option message.

## Test plan

- [x] `a2a-wallet x402 sign` without `--extra-name` → CLI exits with required option error
- [x] `a2a-wallet x402 sign` without `--extra-version` → CLI exits with required option error
- [x] Full `x402 sign` with all required flags → signs and returns `PaymentPayload` successfully

Closes #25, #26