### PR TITLE
feat(device-auth): migrate device code store from in-memory to postgres

### DIFF
--- a/apps/web/drizzle/migrations/0001_device_nonces.sql
+++ b/apps/web/drizzle/migrations/0001_device_nonces.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "device_nonces" (
+	"nonce" text PRIMARY KEY NOT NULL,
+	"token" text,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/apps/web/drizzle/migrations/meta/_journal.json
+++ b/apps/web/drizzle/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1773128666937,
       "tag": "0000_wild_ken_ellis",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1773215066937,
+      "tag": "0001_device_nonces",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/app/api/auth/device/complete/route.ts
+++ b/apps/web/src/app/api/auth/device/complete/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Missing nonce or privyToken' }, { status: 400 });
   }
 
-  const entry = deviceStore.get(nonce);
+  const entry = await deviceStore.get(nonce);
   if (!entry) {
     return NextResponse.json({ error: 'Expired or invalid nonce' }, { status: 404 });
   }
@@ -47,7 +47,7 @@ export async function POST(req: NextRequest) {
     }
 
     const token = await signJwt(claims.userId, embeddedWallet.id);
-    const ok = deviceStore.complete(nonce, token);
+    const ok = await deviceStore.complete(nonce, token);
     if (!ok) {
       return NextResponse.json({ error: 'Nonce expired during token exchange' }, { status: 404 });
     }

--- a/apps/web/src/app/api/auth/device/poll/route.ts
+++ b/apps/web/src/app/api/auth/device/poll/route.ts
@@ -12,7 +12,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'Missing or invalid nonce' }, { status: 400 });
   }
 
-  const entry = deviceStore.get(nonce);
+  const entry = await deviceStore.get(nonce);
   if (!entry) {
     return NextResponse.json({ error: 'Expired or invalid nonce' }, { status: 404 });
   }
@@ -23,7 +23,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ status: 'pending' }, { headers });
   }
 
-  // Token ready — return it and clean up
-  deviceStore.delete(nonce);
+  // Token ready — return it and clean up the consumed nonce row
+  await deviceStore.delete(nonce);
   return NextResponse.json({ status: 'complete', token: entry.token }, { headers });
 }

--- a/apps/web/src/app/api/auth/device/start/route.ts
+++ b/apps/web/src/app/api/auth/device/start/route.ts
@@ -10,7 +10,7 @@ export async function POST(req: NextRequest) {
   if (!allowed) return tooManyRequests(resetAt);
 
   const nonce = randomUUID();
-  deviceStore.create(nonce, TTL_MS);
+  await deviceStore.create(nonce, TTL_MS);
 
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? `${req.nextUrl.protocol}//${req.nextUrl.host}`;
   const loginUrl = `${baseUrl}/device-login?nonce=${encodeURIComponent(nonce)}`;

--- a/apps/web/src/components/install-section.tsx
+++ b/apps/web/src/components/install-section.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useSyncExternalStore, useState } from 'react';
 import { CopyButton } from './ui';
 
 const platforms = ['macOS / Linux', 'Windows'] as const;
@@ -179,14 +179,18 @@ function WindowsGuide() {
   );
 }
 
+const noop = () => () => {};
+const getClientPlatform = (): Platform =>
+  navigator.userAgent.toLowerCase().includes('win') ? 'Windows' : 'macOS / Linux';
+const getServerPlatform = (): Platform => 'macOS / Linux';
+
 export function InstallSection() {
-  // Initializer function avoids calling setState inside useEffect (react-hooks/set-state-in-effect).
-  // typeof navigator guard is required for SSR (navigator is not available server-side).
-  const [active, setActive] = useState<Platform>(() =>
-    typeof navigator !== 'undefined' && navigator.userAgent.toLowerCase().includes('win')
-      ? 'Windows'
-      : 'macOS / Linux'
-  );
+  // useSyncExternalStore gives 'macOS / Linux' on both server and first client render
+  // (matching SSR output), then switches to the real platform after hydration.
+  // This avoids both hydration mismatch and the react-hooks/set-state-in-effect rule.
+  const detected = useSyncExternalStore(noop, getClientPlatform, getServerPlatform);
+  const [override, setOverride] = useState<Platform | null>(null);
+  const active = override ?? detected;
 
   return (
     <div className="w-full max-w-2xl">
@@ -201,7 +205,7 @@ export function InstallSection() {
         {platforms.map((p) => (
           <button
             key={p}
-            onClick={() => setActive(p)}
+            onClick={() => setOverride(p)}
             className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors cursor-pointer ${
               active === p ? 'bg-zinc-700 text-zinc-100' : 'text-zinc-500 hover:text-zinc-300'
             }`}

--- a/apps/web/src/lib/device-store.ts
+++ b/apps/web/src/lib/device-store.ts
@@ -1,58 +1,86 @@
-// In-memory device code store for Device Code Flow (RFC 8628 style).
-// Single-instance only. To support horizontal scaling, replace the
-// MemoryDeviceStore implementation with a Redis/Upstash-backed one
-// that satisfies the same DeviceStore interface.
+// DB-backed device code store for Device Code Flow (RFC 8628 style).
+// Replaces the previous in-memory implementation to support horizontal scaling
+// across multiple server instances without shared state.
+
+import { and, eq, gt } from 'drizzle-orm';
+import { db } from './db';
+import { deviceNonces } from './schema';
 
 export interface DeviceEntry {
   token?: string;
-  expiresAt: number; // Unix timestamp (ms)
+  expiresAt: Date;
 }
 
 export interface DeviceStore {
-  create(nonce: string, ttlMs: number): void;
-  get(nonce: string): DeviceEntry | undefined;
-  complete(nonce: string, token: string): boolean;
-  delete(nonce: string): void;
+  create(nonce: string, ttlMs: number): Promise<void>;
+  get(nonce: string): Promise<DeviceEntry | undefined>;
+  complete(nonce: string, token: string): Promise<boolean>;
+  delete(nonce: string): Promise<void>;
 }
 
-class MemoryDeviceStore implements DeviceStore {
-  private readonly map = new Map<string, DeviceEntry>();
-
-  constructor() {
-    // Purge expired entries every minute
-    setInterval(() => {
-      const now = Date.now();
-      for (const [key, val] of this.map) {
-        if (val.expiresAt < now) this.map.delete(key);
-      }
-    }, 60_000).unref();
+class DbDeviceStore implements DeviceStore {
+  /**
+   * Inserts a new nonce row with an expiry derived from the given TTL.
+   */
+  async create(nonce: string, ttlMs: number): Promise<void> {
+    const expiresAt = new Date(Date.now() + ttlMs);
+    await db.insert(deviceNonces).values({ nonce, expiresAt });
   }
 
-  create(nonce: string, ttlMs: number): void {
-    this.map.set(nonce, { expiresAt: Date.now() + ttlMs });
+  /**
+   * Returns the entry for the given nonce only if it exists and has not expired.
+   * Expiry is enforced at query time; no periodic cleanup job is needed.
+   */
+  async get(nonce: string): Promise<DeviceEntry | undefined> {
+    const now = new Date();
+    const rows = await db
+      .select()
+      .from(deviceNonces)
+      .where(
+        and(
+          eq(deviceNonces.nonce, nonce),
+          gt(deviceNonces.expiresAt, now),
+        ),
+      )
+      .limit(1);
+
+    const row = rows[0];
+    if (!row) return undefined;
+
+    return {
+      token:     row.token ?? undefined,
+      expiresAt: row.expiresAt,
+    };
   }
 
-  get(nonce: string): DeviceEntry | undefined {
-    const entry = this.map.get(nonce);
-    if (!entry) return undefined;
-    if (entry.expiresAt < Date.now()) {
-      this.map.delete(nonce);
-      return undefined;
-    }
-    return entry;
+  /**
+   * Sets the JWT token on a nonce row, but only if the row exists and has not expired.
+   * Returns false when the nonce is missing or already expired.
+   */
+  async complete(nonce: string, token: string): Promise<boolean> {
+    const now = new Date();
+    const result = await db
+      .update(deviceNonces)
+      .set({ token })
+      .where(
+        and(
+          eq(deviceNonces.nonce, nonce),
+          gt(deviceNonces.expiresAt, now),
+        ),
+      )
+      .returning({ nonce: deviceNonces.nonce });
+
+    return result.length > 0;
   }
 
-  complete(nonce: string, token: string): boolean {
-    const entry = this.get(nonce);
-    if (!entry) return false;
-    this.map.set(nonce, { ...entry, token });
-    return true;
-  }
-
-  delete(nonce: string): void {
-    this.map.delete(nonce);
+  /**
+   * Removes the nonce row from the database (called after the token is consumed).
+   */
+  async delete(nonce: string): Promise<void> {
+    await db.delete(deviceNonces).where(eq(deviceNonces.nonce, nonce));
   }
 }
 
-// Module-level singleton — shared across all API route invocations in the same process.
-export const deviceStore: DeviceStore = new MemoryDeviceStore();
+// Module-level singleton — one DB connection pool is shared across all
+// API route invocations within the same process.
+export const deviceStore: DeviceStore = new DbDeviceStore();

--- a/apps/web/src/lib/schema.ts
+++ b/apps/web/src/lib/schema.ts
@@ -6,10 +6,20 @@ export const userPaymentLimits = pgTable(
     id:        serial('id').primaryKey(),
     userId:    text('user_id').notNull(),
     network:   text('network').notNull(),
-    asset:     text('asset').notNull(),       // 소문자로 정규화
+    asset:     text('asset').notNull(),       // normalized to lowercase
     maxAmount: text('max_amount').notNull(),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [unique('user_network_asset_idx').on(t.userId, t.network, t.asset)],
 );
+
+// Stores short-lived nonces for the Device Code Flow (RFC 8628 style).
+// Replaces the previous in-memory store to support horizontal scaling.
+export const deviceNonces = pgTable('device_nonces', {
+  nonce:     text('nonce').primaryKey(),
+  // Populated by the /complete endpoint after the user authenticates.
+  token:     text('token'),
+  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+});


### PR DESCRIPTION
## Summary

- Replace the singleton `MemoryDeviceStore` with a DB-backed `DbDeviceStore`
  using Drizzle ORM, enabling the Device Code Flow to work correctly across
  multiple server instances (horizontal scaling).
- Add `device_nonces` table (migration `0001_device_nonces`) to persist nonces
  with their expiry timestamp and optional JWT token.
- Update all three device-auth API routes (`/start`, `/complete`, `/poll`) to
  `await` the now-async `DeviceStore` interface methods.
- Fix hydration mismatch in `InstallSection` by replacing the `useState`
  initializer with `useSyncExternalStore`, which returns the SSR-safe default
  on the server and first client render, then switches to the detected platform
  after hydration.

## Motivation

The previous in-memory store required all requests to land on the same process.
Moving state to the database removes that constraint without changing the
external Device Code Flow API.

## Migration

Run the following before deploying:

```sh
pnpm --filter web db:migrate
```

Close #29