### PR TITLE
feat(settings): allow users to configure JWT expiry via web UI (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Supports Claude Code, Cursor, GitHub Copilot, Gemini CLI, and any [Agent Skills]
 ```bash
 cd apps/web
 cp .env.example .env
-# Fill in environment variables
+# Fill in environment variables (see apps/web/README.md)
+pnpm db:migrate   # requires DATABASE_URL
 pnpm dev
 ```
 
@@ -60,10 +61,12 @@ See each app's README for details:
 ```
 a2a-x402-wallet/
 ├── apps/
-│   ├── web/          # Next.js web app (Privy wallet, signing API)
+│   ├── web/          # Next.js web app (Privy wallet, signing API, settings)
 │   └── cli/          # CLI tool (a2a-wallet)
 ├── packages/
 │   └── x402/         # Shared x402 protocol types and utilities
+├── skills/
+│   └── a2a-wallet/   # Agent Skill (YAML + Markdown, for Claude Code etc.)
 └── docs/
     ├── a2a-x402-spec-v0.2.md   # A2A x402 protocol specification
     └── cli-requirements.md     # CLI requirements document

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -146,6 +146,43 @@ Returns the authenticated user's information for the current accessToken.
 
 ---
 
+### `POST /api/faucet`
+
+Sends 1 testnet USDC (Base Sepolia) to the authenticated user's wallet. Rate-limited to prevent abuse.
+
+**Authorization**: Privy token
+
+**Request**: no body
+
+**Response**:
+```json
+{ "transaction": "0x..." }
+```
+
+**Errors**:
+- `400` — Wallet balance is already above the threshold (0.1 USDC)
+- `401` — Invalid Privy token
+- `500` — Transfer failed
+
+---
+
+### `POST /api/graphql`
+
+GraphQL API for user settings and payment limits. Uses `graphql-yoga`.
+
+**Authorization**: Privy token
+
+**Queries**:
+- `userSettings` — Returns `{ jwtExpiresIn }` (current per-user JWT expiry override; `null` means server default)
+- `paymentLimits` — Returns list of `{ network, asset, maxAmount, isDefault }` entries
+
+**Mutations**:
+- `setJwtExpiresIn(value: String)` — Set or clear per-user JWT expiry override. Format: `5m`, `1h`, `24h`, `7d`. Pass `null` to revert to server default.
+- `setPaymentLimit(network, asset, maxAmount)` — Upsert a payment limit for a token
+- `deletePaymentLimit(network, asset)` — Remove a payment limit
+
+---
+
 ### `POST /api/x402/sign`
 
 Signs x402 `PaymentRequirements` and returns a `PaymentPayload`. Uses ERC-3009 TransferWithAuthorization (EIP-712).
@@ -226,10 +263,22 @@ cp .env.example .env
 | `NEXT_PUBLIC_PRIVY_AUTHORIZATION_KEY_ID` | Privy delegation signing key ID (client-side) |
 | `PRIVY_AUTHORIZATION_PRIVATE_KEY` | Private key for delegation signing |
 | `JWT_SECRET` | Secret for signing accessTokens |
-| `JWT_EXPIRATION_TIME` | accessToken expiry (default: `5m`) |
+| `JWT_EXPIRATION_TIME` | Server-default accessToken expiry (default: `5m`). Users can override this per-account in Settings. |
 | `NEXT_PUBLIC_APP_URL` | Public URL of this app, used to build device-login URLs (required in production) |
+| `DATABASE_URL` | PostgreSQL connection string (used for device code store, payment limits, and user settings) |
+| `FAUCET_ADMIN_WALLET_ID` | Privy wallet ID of the faucet admin wallet (Base Sepolia) |
+| `FAUCET_ADMIN_ADDRESS` | Ethereum address corresponding to `FAUCET_ADMIN_WALLET_ID` |
 
-### 3. Run development server
+### 3. Set up the database
+
+A PostgreSQL database is required for the device code store, payment limits, and user settings.
+
+```bash
+# Run database migrations
+pnpm db:migrate
+```
+
+### 4. Run development server
 
 ```bash
 pnpm dev
@@ -237,7 +286,7 @@ pnpm dev
 
 Open [http://localhost:3000](http://localhost:3000), log in, and delegate your wallet.
 
-### 4. Build
+### 5. Build
 
 ```bash
 pnpm build
@@ -245,8 +294,11 @@ pnpm build
 
 ## Tech Stack
 
-- **Next.js 16** (App Router)
+- **Next.js 15** (App Router)
 - **Privy** — Embedded wallets, social login, server-side signing
+- **PostgreSQL** — Device code store, payment limits, user settings
+- **Drizzle ORM** — Database schema and migrations
+- **graphql-yoga** — GraphQL API for settings/limits
 - **jose** — JWT signing and verification
 - **Tailwind CSS**
 - **TypeScript**

--- a/apps/web/drizzle.config.ts
+++ b/apps/web/drizzle.config.ts
@@ -1,3 +1,16 @@
+// ⚠️  MIGRATION WORKFLOW — read before touching drizzle/migrations/
+//
+// ALWAYS use drizzle-kit to create migrations. Never write SQL files manually.
+//
+//   1. Edit src/lib/schema.ts
+//   2. pnpm db:generate   ← generates SQL + updates meta/_journal.json + snapshot
+//   3. pnpm db:migrate    ← applies to local DB
+//
+// WHY: drizzle-orm's migrate() (used in production via `fly deploy` release_command)
+// reads meta/_journal.json to decide which SQL files to run.
+// A manually created SQL file that is NOT listed in the journal will be silently skipped
+// in both local and production environments.
+
 import { defineConfig } from 'drizzle-kit';
 
 export default defineConfig({

--- a/apps/web/drizzle/migrations/0002_user_settings.sql
+++ b/apps/web/drizzle/migrations/0002_user_settings.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "user_settings" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"jwt_expires_in" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "user_settings_user_id_unique" UNIQUE("user_id")
+);

--- a/apps/web/drizzle/migrations/README.md
+++ b/apps/web/drizzle/migrations/README.md
@@ -1,0 +1,40 @@
+# Database Migrations
+
+> **Never create `.sql` files in this directory by hand.**
+
+## Correct workflow
+
+```bash
+# 1. Edit src/lib/schema.ts
+
+# 2. Generate migration (creates SQL + updates meta/_journal.json + snapshot)
+pnpm db:generate
+
+# 3. Apply to local DB
+pnpm db:migrate
+```
+
+## Why this matters
+
+`drizzle-orm`'s `migrate()` function — used in production via Fly.io's `release_command` — reads
+`meta/_journal.json` to determine which SQL files to run.
+
+**A manually written `.sql` file that is not registered in `_journal.json` will be silently skipped
+in both local and production environments.**
+
+This is what happened with `0002_user_settings.sql`: the file existed but the journal entry was
+missing, so the `user_settings` table was never created until the journal was fixed manually.
+
+## Production deployment
+
+Migrations run automatically on every `fly deploy` before the new app version receives traffic:
+
+```
+fly deploy
+  └─► release_command: node apps/web/migrate.mjs
+        └─► drizzle-orm migrate() reads _journal.json → applies pending migrations
+  └─► app server starts
+```
+
+The `migrate.mjs` bundle and the `migrations/` folder are both embedded in the Docker image at
+build time, so whatever is in this directory at deploy time is what runs in production.

--- a/apps/web/drizzle/migrations/meta/_journal.json
+++ b/apps/web/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1773215066937,
       "tag": "0001_device_nonces",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1773301466937,
+      "tag": "0002_user_settings",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/app/api/auth/device/complete/route.ts
+++ b/apps/web/src/app/api/auth/device/complete/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { eq } from 'drizzle-orm';
 import { privy } from '@/lib/privy';
 import { signJwt } from '@/lib/jwt';
+import { db } from '@/lib/db';
+import { userSettings } from '@/lib/schema';
 import { deviceStore } from '@/lib/device-store';
 import { completeLimiter, getClientIp, tooManyRequests } from '@/lib/rate-limit';
 import type { WalletWithMetadata } from '@privy-io/server-auth';
@@ -46,7 +49,15 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'No delegated embedded wallet found' }, { status: 400 });
     }
 
-    const token = await signJwt(claims.userId, embeddedWallet.id);
+    // Look up the user's custom JWT expiry setting; fall back to server default if absent
+    const settingRows = await db
+      .select({ jwtExpiresIn: userSettings.jwtExpiresIn })
+      .from(userSettings)
+      .where(eq(userSettings.userId, claims.userId))
+      .limit(1);
+    const jwtExpiresIn = settingRows[0]?.jwtExpiresIn ?? undefined;
+
+    const token = await signJwt(claims.userId, embeddedWallet.id, jwtExpiresIn);
     const ok = await deviceStore.complete(nonce, token);
     if (!ok) {
       return NextResponse.json({ error: 'Nonce expired during token exchange' }, { status: 404 });

--- a/apps/web/src/app/api/auth/token/route.ts
+++ b/apps/web/src/app/api/auth/token/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { eq } from 'drizzle-orm';
 import { privy } from '@/lib/privy';
 import { signJwt } from '@/lib/jwt';
+import { db } from '@/lib/db';
+import { userSettings } from '@/lib/schema';
 import type { WalletWithMetadata } from '@privy-io/server-auth';
 
 export async function POST(req: NextRequest) {
@@ -27,7 +30,15 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'No delegated embedded wallet found' }, { status: 400 });
     }
 
-    const token = await signJwt(claims.userId, embeddedWallet.id);
+    // Look up the user's custom JWT expiry setting; fall back to server default if absent
+    const settingRows = await db
+      .select({ jwtExpiresIn: userSettings.jwtExpiresIn })
+      .from(userSettings)
+      .where(eq(userSettings.userId, claims.userId))
+      .limit(1);
+    const jwtExpiresIn = settingRows[0]?.jwtExpiresIn ?? undefined;
+
+    const token = await signJwt(claims.userId, embeddedWallet.id, jwtExpiresIn);
     return NextResponse.json({ token });
   } catch {
     return NextResponse.json({ error: 'Invalid Privy token' }, { status: 401 });

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -48,6 +48,14 @@ async function gql<T = unknown>(
   return res.json() as Promise<{ data?: T; errors?: { message: string }[] }>;
 }
 
+const USER_SETTINGS_QUERY = `
+  query { userSettings { jwtExpiresIn jwtExpiresInDefault } }
+`;
+
+const SET_JWT_EXPIRES_IN_MUTATION = `
+  mutation SetJwtExpiresIn($value: String) { setJwtExpiresIn(value: $value) { jwtExpiresIn jwtExpiresInDefault } }
+`;
+
 const PAYMENT_LIMITS_QUERY = `
   query { paymentLimits { network asset maxAmount isDefault } }
 `;
@@ -204,6 +212,9 @@ export default function SettingsPage() {
         )}
       </Section>
 
+      {/* JWT Expiry */}
+      <JwtExpirySection getAccessToken={getAccessToken} />
+
       {/* Payment Limits */}
       <PaymentLimitsSection getAccessToken={getAccessToken} />
 
@@ -285,6 +296,138 @@ export default function SettingsPage() {
         <BtnGhost onClick={logout}>Sign out</BtnGhost>
       </div>
     </Shell>
+  );
+}
+
+// ── JWT Expiry Section ────────────────────────────────────────────────────────
+
+function JwtExpirySection({ getAccessToken }: { getAccessToken: () => Promise<string | null> }) {
+  const [current, setCurrent]         = useState<string | null | undefined>(undefined); // undefined = not yet loaded
+  const [serverDefault, setServerDefault] = useState<string | null>(null);
+  const [loading, setLoading]         = useState(true);
+  const [fetchError, setFetchError]   = useState<string | null>(null);
+
+  const [inputValue, setInputValue] = useState('');
+  const [saving, setSaving]         = useState(false);
+  const [saveError, setSaveError]   = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+
+  const fetchSetting = useCallback(async () => {
+    setLoading(true);
+    setFetchError(null);
+    try {
+      const token = await getAccessToken();
+      if (!token) throw new Error('Not authenticated');
+      const result = await gql<{ userSettings: { jwtExpiresIn: string | null; jwtExpiresInDefault: string } | null }>(
+        USER_SETTINGS_QUERY, {}, token,
+      );
+      if (result.errors?.length) throw new Error(result.errors[0].message);
+      setCurrent(result.data?.userSettings?.jwtExpiresIn ?? null);
+      setServerDefault(result.data?.userSettings?.jwtExpiresInDefault ?? null);
+    } catch (err) {
+      setFetchError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [getAccessToken]);
+
+  useEffect(() => { fetchSetting(); }, [fetchSetting]);
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setSaveError(null);
+    setSaveSuccess(false);
+    try {
+      const token = await getAccessToken();
+      if (!token) throw new Error('Not authenticated');
+      const value = inputValue.trim() || null;
+      const result = await gql<{ setJwtExpiresIn: { jwtExpiresIn: string | null; jwtExpiresInDefault: string } }>(
+        SET_JWT_EXPIRES_IN_MUTATION, { value }, token,
+      );
+      if (result.errors?.length) throw new Error(result.errors[0].message);
+      setCurrent(result.data?.setJwtExpiresIn.jwtExpiresIn ?? null);
+      setServerDefault(result.data?.setJwtExpiresIn.jwtExpiresInDefault ?? null);
+      setInputValue('');
+      setSaveSuccess(true);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleClear() {
+    setSaving(true);
+    setSaveError(null);
+    setSaveSuccess(false);
+    try {
+      const token = await getAccessToken();
+      if (!token) throw new Error('Not authenticated');
+      const result = await gql<{ setJwtExpiresIn: { jwtExpiresIn: string | null; jwtExpiresInDefault: string } }>(
+        SET_JWT_EXPIRES_IN_MUTATION, { value: null }, token,
+      );
+      if (result.errors?.length) throw new Error(result.errors[0].message);
+      setCurrent(null);
+      setServerDefault(result.data?.setJwtExpiresIn.jwtExpiresInDefault ?? null);
+      setInputValue('');
+      setSaveSuccess(true);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Section title="CLI Token Expiry">
+      <Row label="Current setting">
+        {loading ? (
+          <span className="text-xs text-zinc-500 animate-pulse">Loading…</span>
+        ) : fetchError ? (
+          <span className="text-xs text-red-400">{fetchError}</span>
+        ) : current ? (
+          <span className="text-sm text-zinc-300 font-mono">{current}</span>
+        ) : (
+          <span className="text-xs text-zinc-500">
+            Using server default{serverDefault ? <> (<span className="font-mono">{serverDefault}</span>)</> : ''}
+          </span>
+        )}
+      </Row>
+
+      <form onSubmit={handleSave} className="space-y-2 pt-1">
+        <div className="flex gap-2">
+          <input
+            type="text"
+            placeholder="e.g. 5m, 1h, 24h, 7d"
+            value={inputValue}
+            onChange={(e) => { setInputValue(e.target.value); setSaveSuccess(false); }}
+            disabled={saving}
+            className="flex-1 rounded-lg border border-zinc-700 bg-zinc-800/60 px-3 py-2 text-xs text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500 transition-colors disabled:opacity-50"
+          />
+          <BtnPrimary type="submit" disabled={saving || !inputValue.trim()}>
+            {saving ? 'Saving…' : 'Save'}
+          </BtnPrimary>
+          {current && (
+            <BtnSecondary type="button" onClick={handleClear} disabled={saving}>
+              Clear
+            </BtnSecondary>
+          )}
+        </div>
+
+        <p className="text-[11px] text-zinc-600 leading-relaxed">
+          Accepted formats: <span className="font-mono text-zinc-500">5m</span>,{' '}
+          <span className="font-mono text-zinc-500">30m</span>,{' '}
+          <span className="font-mono text-zinc-500">1h</span>,{' '}
+          <span className="font-mono text-zinc-500">24h</span>,{' '}
+          <span className="font-mono text-zinc-500">7d</span>.
+          Leave empty and click Save, or use Clear, to revert to the server default.
+        </p>
+
+        {saveError && <p className="text-xs text-red-400">{saveError}</p>}
+        {saveSuccess && <p className="text-xs text-emerald-400">Saved.</p>}
+      </form>
+    </Section>
   );
 }
 

--- a/apps/web/src/lib/graphql/schema.ts
+++ b/apps/web/src/lib/graphql/schema.ts
@@ -2,9 +2,30 @@ import { eq, and } from 'drizzle-orm';
 import { GraphQLError } from 'graphql';
 import { getChainId } from '@a2a-x402-wallet/x402';
 import { db } from '../db';
-import { userPaymentLimits } from '../schema';
+import { userPaymentLimits, userSettings } from '../schema';
 import { mergeWithDefaults } from '../default-payment-limits';
 import { builder } from './builder';
+import { defaultExpirationTime } from '../jwt';
+
+// ── UserSettings ──────────────────────────────────────────────────────────────
+
+/** Format accepted for jwtExpiresIn: a positive integer followed by s/m/h/d. */
+const JWT_EXPIRES_IN_RE = /^\d+[smhd]$/;
+
+interface UserSettingsShape {
+  jwtExpiresIn: string | null;
+  jwtExpiresInDefault: string;
+}
+
+const UserSettings = builder.objectRef<UserSettingsShape>('UserSettings').implement({
+  fields: (t) => ({
+    // null means the server default (JWT_EXPIRATION_TIME env var) is in use
+    jwtExpiresIn: t.exposeString('jwtExpiresIn', { nullable: true }),
+    jwtExpiresInDefault: t.exposeString('jwtExpiresInDefault'),
+  }),
+});
+
+// ── PaymentLimit ──────────────────────────────────────────────────────────────
 
 interface PaymentLimitShape {
   network:   string;
@@ -24,6 +45,21 @@ const PaymentLimit = builder.objectRef<PaymentLimitShape>('PaymentLimit').implem
 
 builder.queryType({
   fields: (t) => ({
+    userSettings: t.field({
+      type:     UserSettings,
+      nullable: true,
+      resolve:  async (_root, _args, ctx): Promise<UserSettingsShape> => {
+        if (!ctx.userId) throw new GraphQLError('Unauthorized', { extensions: { code: 'UNAUTHORIZED' } });
+        const rows = await db
+          .select({ jwtExpiresIn: userSettings.jwtExpiresIn })
+          .from(userSettings)
+          .where(eq(userSettings.userId, ctx.userId))
+          .limit(1);
+        // Return a shape with null jwtExpiresIn when the user has no saved setting
+        return { jwtExpiresIn: rows[0]?.jwtExpiresIn ?? null, jwtExpiresInDefault: defaultExpirationTime };
+      },
+    }),
+
     paymentLimits: t.field({
       type:    [PaymentLimit],
       resolve: async (_root, _args, ctx) => {
@@ -44,6 +80,37 @@ builder.queryType({
 
 builder.mutationType({
   fields: (t) => ({
+    setJwtExpiresIn: t.field({
+      type: UserSettings,
+      args: {
+        // null clears the per-user override, reverting to the server default
+        value: t.arg.string({ required: false }),
+      },
+      resolve: async (_root, args, ctx): Promise<UserSettingsShape> => {
+        if (!ctx.userId) throw new GraphQLError('Unauthorized', { extensions: { code: 'UNAUTHORIZED' } });
+
+        const value = args.value ?? null;
+
+        // Validate format when a value is provided: e.g. 5m, 1h, 24h, 7d
+        if (value !== null && !JWT_EXPIRES_IN_RE.test(value)) {
+          throw new GraphQLError(
+            'Invalid jwtExpiresIn format. Use a positive integer followed by s, m, h, or d (e.g. 5m, 1h, 24h, 7d).',
+            { extensions: { code: 'BAD_USER_INPUT' } },
+          );
+        }
+
+        await db
+          .insert(userSettings)
+          .values({ userId: ctx.userId, jwtExpiresIn: value, updatedAt: new Date() })
+          .onConflictDoUpdate({
+            target: userSettings.userId,
+            set:    { jwtExpiresIn: value, updatedAt: new Date() },
+          });
+
+        return { jwtExpiresIn: value, jwtExpiresInDefault: defaultExpirationTime };
+      },
+    }),
+
     setPaymentLimit: t.field({
       type: PaymentLimit,
       args: {

--- a/apps/web/src/lib/jwt.ts
+++ b/apps/web/src/lib/jwt.ts
@@ -3,13 +3,18 @@ import { SignJWT, jwtVerify } from 'jose';
 const jwtSecret = process.env.JWT_SECRET;
 if (!jwtSecret) throw new Error('JWT_SECRET environment variable is required');
 const secret = new TextEncoder().encode(jwtSecret);
-const expirationTime = process.env.JWT_EXPIRATION_TIME || '5m';
+export const defaultExpirationTime = process.env.JWT_EXPIRATION_TIME || '5m';
+const expirationTime = defaultExpirationTime;
 
-export async function signJwt(userId: string, walletId: string): Promise<string> {
+/**
+ * Signs a JWT for the given user/wallet pair.
+ * @param expiresIn - Optional per-user override; falls back to JWT_EXPIRATION_TIME env var.
+ */
+export async function signJwt(userId: string, walletId: string, expiresIn?: string): Promise<string> {
   return new SignJWT({ sub: userId, walletId })
     .setProtectedHeader({ alg: 'HS256' })
     .setIssuedAt()
-    .setExpirationTime(expirationTime)
+    .setExpirationTime(expiresIn ?? expirationTime)
     .sign(secret);
 }
 

--- a/apps/web/src/lib/schema.ts
+++ b/apps/web/src/lib/schema.ts
@@ -1,5 +1,15 @@
 import { pgTable, serial, text, timestamp, unique } from 'drizzle-orm/pg-core';
 
+// Per-user settings persisted in the database.
+// jwtExpiresIn: null means fall back to the JWT_EXPIRATION_TIME env var.
+export const userSettings = pgTable('user_settings', {
+  id:           serial('id').primaryKey(),
+  userId:       text('user_id').notNull().unique(),
+  jwtExpiresIn: text('jwt_expires_in'),
+  createdAt:    timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt:    timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+});
+
 export const userPaymentLimits = pgTable(
   'user_payment_limits',
   {


### PR DESCRIPTION
## Summary

Allow users to configure a custom JWT token expiry duration via the web
Settings UI. If no custom value is set, the server-side default is used.

## Changes

- **DB**: Add `user_settings` table with `jwt_expires_in` column (Drizzle migration `0002`)
- **GraphQL**: Add `userSettings` query and `setJwtExpiresIn` mutation to schema
- **JWT**: Accept optional `expiresIn` override in `signJwt()`
- **Auth routes**: Look up per-user expiry from DB before issuing tokens
  (`/api/auth/token` and `/api/auth/device/complete`)
- **Settings UI**: Add "CLI Token Expiry" section with set/clear controls

## How it works

1. User sets a duration (e.g. `5m`, `1h`, `7d`) in Settings → CLI Token Expiry
2. On next login/device auth, the issued JWT reflects that duration
3. Clearing the setting reverts to the server default

Close #30 