### PR TITLE
feat(web): store x402 accepts options in DB

### DIFF
--- a/apps/web/drizzle/migrations/0006_funny_anita_blake.sql
+++ b/apps/web/drizzle/migrations/0006_funny_anita_blake.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "x402_accepts_configs" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"accepts" json NOT NULL,
+	"is_active" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "x402_accepts_configs_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+CREATE TABLE "x402_pending_tasks" (
+	"task_id" text PRIMARY KEY NOT NULL,
+	"payment_requirements" json NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/apps/web/drizzle/migrations/meta/0006_snapshot.json
+++ b/apps/web/drizzle/migrations/meta/0006_snapshot.json
@@ -1,0 +1,404 @@
+{
+  "id": "a7100b89-389b-4c73-9efa-1a50c3fb4cba",
+  "prevId": "8656a8e5-97a4-49ce-9786-ddc6dab564fe",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.a2a_api_keys": {
+      "name": "a2a_api_keys",
+      "schema": "",
+      "columns": {
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.a2a_device_codes": {
+      "name": "a2a_device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_device_codes": {
+      "name": "cli_device_codes",
+      "schema": "",
+      "columns": {
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_device_codes_user_code_unique": {
+          "name": "cli_device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_nonces": {
+      "name": "device_nonces",
+      "schema": "",
+      "columns": {
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_payment_limits": {
+      "name": "user_payment_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset": {
+          "name": "asset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_amount": {
+          "name": "max_amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_network_asset_idx": {
+          "name": "user_network_asset_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "network",
+            "asset"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jwt_expires_in": {
+          "name": "jwt_expires_in",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.x402_accepts_configs": {
+      "name": "x402_accepts_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepts": {
+          "name": "accepts",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "x402_accepts_configs_name_unique": {
+          "name": "x402_accepts_configs_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.x402_pending_tasks": {
+      "name": "x402_pending_tasks",
+      "schema": "",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payment_requirements": {
+          "name": "payment_requirements",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/migrations/meta/_journal.json
+++ b/apps/web/drizzle/migrations/meta/_journal.json
@@ -22,26 +22,33 @@
       "when": 1773301466937,
       "tag": "0002_user_settings",
       "breakpoints": true
-    }
-    ,{
+    },
+    {
       "idx": 3,
       "version": "7",
       "when": 1773301466937,
       "tag": "0003_a2a_device_flow",
       "breakpoints": true
-    }
-    ,{
+    },
+    {
       "idx": 4,
       "version": "7",
       "when": 1773387866937,
       "tag": "0004_recreate_a2a_tables",
       "breakpoints": true
-    }
-    ,{
+    },
+    {
       "idx": 5,
       "version": "7",
       "when": 1773474266937,
       "tag": "0005_cli_device_codes",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1773703347928,
+      "tag": "0006_funny_anita_blake",
       "breakpoints": true
     }
   ]

--- a/apps/web/fly.toml.example
+++ b/apps/web/fly.toml.example
@@ -18,6 +18,11 @@ primary_region = 'nrt'
   APP_URL = 'set-your-domain'
 
   # x402 payment extension (Merchant Agent config)
+  #
+  # Option 1 (recommended): multi-accepts JSON array — supports multiple networks/assets
+  # A2A_X402_ACCEPTS = '[{"scheme":"exact","network":"base","asset":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","payTo":"0xYOUR_WALLET","maxAmountRequired":"1000000","extra":{"name":"USDC","version":"2"}},{"scheme":"exact","network":"base-sepolia","asset":"0x036CbD53842c5426634e7929541eC2318f3dCF7e","payTo":"0xYOUR_WALLET","maxAmountRequired":"1000000","extra":{"name":"USDC","version":"2"}}]'
+  #
+  # Option 2 (legacy): single-option env vars — used when A2A_X402_ACCEPTS is not set
   A2A_X402_PAY_TO=''
   A2A_X402_NETWORK = 'base-sepolia'
   A2A_X402_ASSET = '0x036CbD53842c5426634e7929541eC2318f3dCF7e'

--- a/apps/web/src/app/api/a2a/route.ts
+++ b/apps/web/src/app/api/a2a/route.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { a2aDeviceStore } from '@/lib/a2a-device-store';
+import { x402Store } from '@/lib/x402-store';
 import {
   NETWORKS,
   type NetworkName,
@@ -67,26 +68,6 @@ async function settlePayment(
     return { success: false, transaction: data.transaction ?? '', network: data.network ?? requirements.network, payer: data.payer, errorReason: data.errorReason ?? `http_${response.status}` };
   }
   return { success: true, transaction: data.transaction, network: data.network, payer: data.payer };
-}
-
-// ---------------------------------------------------------------------------
-// In-memory task store for pending x402 payment tasks.
-// Maps taskId → PaymentRequirements that were issued for that task.
-// ---------------------------------------------------------------------------
-interface PendingPaymentTask {
-  paymentRequirements: PaymentRequirements[];
-  createdAt: number;
-}
-
-const pendingTasks = new Map<string, PendingPaymentTask>();
-
-// Clean up tasks older than 30 minutes
-const TASK_TTL_MS = 30 * 60 * 1000;
-function evictStaleTasks() {
-  const cutoff = Date.now() - TASK_TTL_MS;
-  for (const [id, task] of pendingTasks) {
-    if (task.createdAt < cutoff) pendingTasks.delete(id);
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -178,10 +159,36 @@ function makePaymentFailedTask(taskId: string, reason: string, errorCode: string
 }
 
 // ---------------------------------------------------------------------------
-// Payment requirements from environment
+// Payment requirements — DB first, env vars as fallback
 // ---------------------------------------------------------------------------
 
-function getPaymentRequirements(): PaymentRequirements | null {
+/**
+ * Returns the list of accepted payment options.
+ *
+ * Priority:
+ *   1. DB active config (x402_accepts_configs where is_active = true)
+ *   2. A2A_X402_ACCEPTS — JSON array of PaymentRequirements (multi-option env var)
+ *   3. Legacy single-option env vars (A2A_X402_PAY_TO, A2A_X402_NETWORK, etc.)
+ *
+ * Returns null if no payment config is set (dev/echo mode).
+ */
+async function getAcceptedPaymentOptions(): Promise<PaymentRequirements[] | null> {
+  // 1. DB: active config
+  const dbAccepts = await x402Store.getActiveAccepts();
+  if (dbAccepts) return dbAccepts;
+
+  // 2. Multi-option env var: A2A_X402_ACCEPTS as a JSON array
+  const acceptsEnv = process.env.A2A_X402_ACCEPTS;
+  if (acceptsEnv) {
+    try {
+      const parsed = JSON.parse(acceptsEnv) as PaymentRequirements[];
+      if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+    } catch {
+      console.error('[a2a] Invalid A2A_X402_ACCEPTS JSON, falling back to legacy env vars');
+    }
+  }
+
+  // 3. Legacy single-option env vars
   const payTo = process.env.A2A_X402_PAY_TO as `0x${string}` | undefined;
   if (!payTo) return null;
 
@@ -190,17 +197,17 @@ function getPaymentRequirements(): PaymentRequirements | null {
   const asset      = (process.env.A2A_X402_ASSET ?? networkCfg?.usdcAddress) as `0x${string}`;
   const maxAmount  = process.env.A2A_X402_MAX_AMOUNT ?? '1000'; // 0.001 USDC
 
-  return {
-    scheme:             'exact',
+  return [{
+    scheme:            'exact',
     network,
     asset,
     payTo,
-    maxAmountRequired:  maxAmount,
+    maxAmountRequired: maxAmount,
     extra: {
       name:    networkCfg?.usdcEip712.name    ?? 'USDC',
       version: networkCfg?.usdcEip712.version ?? '2',
     },
-  };
+  }];
 }
 
 // ---------------------------------------------------------------------------
@@ -231,7 +238,10 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'invalid_request' }, { status: 400 });
   }
 
-  evictStaleTasks();
+  // Evict stale tasks in the background (non-blocking)
+  x402Store.evictStaleTasks().catch((err) =>
+    console.error('[a2a] evictStaleTasks error:', err),
+  );
 
   const rpcId = body.id ?? null;
 
@@ -253,24 +263,30 @@ export async function POST(req: NextRequest) {
       const taskId  = msg?.taskId ?? '';
       const payload = msg?.metadata?.['x402.payment.payload'] as PaymentPayload | undefined;
 
-      const pending = taskId ? pendingTasks.get(taskId) : undefined;
-      const network = pending?.paymentRequirements[0]?.network ?? 'base-sepolia';
+      const pendingRequirements = taskId ? await x402Store.getPendingTask(taskId) : undefined;
 
       if (!payload) {
+        const network = pendingRequirements?.[0]?.network ?? 'base-sepolia';
         return NextResponse.json({
           jsonrpc: '2.0', id: rpcId,
           result: makePaymentFailedTask(taskId, 'Missing x402.payment.payload in metadata', 'INVALID_SIGNATURE', network),
         });
       }
 
-      if (!pending) {
+      if (!pendingRequirements) {
+        const network = payload.network ?? 'base-sepolia';
         return NextResponse.json({
           jsonrpc: '2.0', id: rpcId,
           result: makePaymentFailedTask(taskId, 'Unknown or expired task', 'EXPIRED_PAYMENT', network),
         });
       }
 
-      const req0 = pending.paymentRequirements[0];
+      // Match submitted payload to the corresponding PaymentRequirements by network + scheme
+      const req0 =
+        pendingRequirements.find(
+          r => r.network === payload.network && r.scheme === payload.scheme,
+        ) ?? pendingRequirements[0];
+      const network = req0.network;
 
       // Verify: signature, amount, recipient, time window (via official facilitator)
       const verifyResult = await verifyPayment(payload, req0);
@@ -300,7 +316,7 @@ export async function POST(req: NextRequest) {
         });
       }
 
-      pendingTasks.delete(taskId);
+      await x402Store.deletePendingTask(taskId);
 
       return NextResponse.json({
         jsonrpc: '2.0', id: rpcId,
@@ -311,7 +327,7 @@ export async function POST(req: NextRequest) {
     // --- Client explicitly rejects payment ---
     if (paymentStatus === 'payment-rejected') {
       const taskId = msg?.taskId ?? randomUUID();
-      pendingTasks.delete(taskId);
+      await x402Store.deletePendingTask(taskId);
 
       return NextResponse.json({
         jsonrpc: '2.0', id: rpcId,
@@ -333,18 +349,15 @@ export async function POST(req: NextRequest) {
     }
 
     // --- Step 1: New service request — require payment if configured ---
-    const requirements = getPaymentRequirements();
+    const requirements = await getAcceptedPaymentOptions();
     const taskId = randomUUID();
 
     if (requirements) {
-      pendingTasks.set(taskId, {
-        paymentRequirements: [requirements],
-        createdAt: Date.now(),
-      });
+      await x402Store.setPendingTask(taskId, requirements);
 
       return NextResponse.json({
         jsonrpc: '2.0', id: rpcId,
-        result: makePaymentRequiredTask(taskId, [requirements]),
+        result: makePaymentRequiredTask(taskId, requirements),
       });
     }
 
@@ -374,12 +387,12 @@ export async function POST(req: NextRequest) {
   // -------------------------------------------------------------------------
   if (body.method === 'tasks/get') {
     const taskId = (body.params?.id as string | undefined) ?? 'unknown';
-    const pending = pendingTasks.get(taskId);
+    const pendingRequirements = await x402Store.getPendingTask(taskId);
 
-    if (pending) {
+    if (pendingRequirements) {
       return NextResponse.json({
         jsonrpc: '2.0', id: rpcId,
-        result: makePaymentRequiredTask(taskId, pending.paymentRequirements),
+        result: makePaymentRequiredTask(taskId, pendingRequirements),
       });
     }
 
@@ -394,7 +407,7 @@ export async function POST(req: NextRequest) {
   // -------------------------------------------------------------------------
   if (body.method === 'tasks/cancel') {
     const taskId = (body.params?.id as string | undefined) ?? 'unknown';
-    pendingTasks.delete(taskId);
+    await x402Store.deletePendingTask(taskId);
 
     return NextResponse.json({
       jsonrpc: '2.0', id: rpcId,

--- a/apps/web/src/lib/schema.ts
+++ b/apps/web/src/lib/schema.ts
@@ -1,4 +1,5 @@
-import { pgTable, serial, text, timestamp, unique } from 'drizzle-orm/pg-core';
+import { boolean, json, pgTable, serial, text, timestamp, unique } from 'drizzle-orm/pg-core';
+import type { PaymentRequirements } from '@a2a-x402-wallet/x402';
 
 // Per-user settings persisted in the database.
 // jwtExpiresIn: null means fall back to the JWT_EXPIRATION_TIME env var.
@@ -51,6 +52,27 @@ export const a2aDeviceCodes = pgTable('a2a_device_codes', {
 export const a2aApiKeys = pgTable('a2a_api_keys', {
   apiKey:    text('api_key').primaryKey(),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+});
+
+// Stores named sets of x402 PaymentRequirements (the accepts array).
+// The active config (is_active = true) is used by the A2A route handler.
+// Falls back to legacy env vars (A2A_X402_ACCEPTS, A2A_X402_PAY_TO, etc.) if no active row exists.
+export const x402AcceptsConfigs = pgTable('x402_accepts_configs', {
+  id:        serial('id').primaryKey(),
+  name:      text('name').notNull().unique(),
+  accepts:   json('accepts').notNull().$type<PaymentRequirements[]>(),
+  isActive:  boolean('is_active').notNull().default(false),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+});
+
+// Stores pending x402 payment tasks by taskId.
+// Replaces the previous in-memory Map to support horizontal scaling.
+export const x402PendingTasks = pgTable('x402_pending_tasks', {
+  taskId:              text('task_id').primaryKey(),
+  paymentRequirements: json('payment_requirements').notNull().$type<PaymentRequirements[]>(),
+  expiresAt:           timestamp('expires_at', { withTimezone: true }).notNull(),
+  createdAt:           timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 });
 
 // Stores short-lived device codes for the RFC 8628-compliant CLI Device Authorization Flow.

--- a/apps/web/src/lib/x402-store.ts
+++ b/apps/web/src/lib/x402-store.ts
@@ -1,0 +1,83 @@
+import { eq, lt } from 'drizzle-orm';
+import type { PaymentRequirements } from '@a2a-x402-wallet/x402';
+import { db } from './db';
+import { x402AcceptsConfigs, x402PendingTasks } from './schema';
+
+const TASK_TTL_MS = 30 * 60 * 1000;
+
+export const x402Store = {
+  // ---------------------------------------------------------------------------
+  // Accepts configs — the set of PaymentRequirements the merchant accepts.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Returns the active accepts config from the DB, or null if none is set.
+   * Callers should fall back to env vars when this returns null.
+   */
+  async getActiveAccepts(): Promise<PaymentRequirements[] | null> {
+    const row = await db.query.x402AcceptsConfigs.findFirst({
+      where: eq(x402AcceptsConfigs.isActive, true),
+    });
+    return row?.accepts ?? null;
+  },
+
+  /**
+   * Upserts a named accepts config and optionally activates it.
+   * If activate=true, all other configs are deactivated first.
+   */
+  async setAcceptsConfig(name: string, accepts: PaymentRequirements[], activate = true): Promise<void> {
+    await db.transaction(async (tx) => {
+      if (activate) {
+        // Deactivate all existing active configs
+        await tx
+          .update(x402AcceptsConfigs)
+          .set({ isActive: false, updatedAt: new Date() })
+          .where(eq(x402AcceptsConfigs.isActive, true));
+      }
+
+      await tx
+        .insert(x402AcceptsConfigs)
+        .values({ name, accepts, isActive: activate, updatedAt: new Date() })
+        .onConflictDoUpdate({
+          target: x402AcceptsConfigs.name,
+          set: { accepts, isActive: activate, updatedAt: new Date() },
+        });
+    });
+  },
+
+  // ---------------------------------------------------------------------------
+  // Pending payment tasks — taskId → PaymentRequirements[], with TTL.
+  // ---------------------------------------------------------------------------
+
+  async setPendingTask(taskId: string, paymentRequirements: PaymentRequirements[]): Promise<void> {
+    const expiresAt = new Date(Date.now() + TASK_TTL_MS);
+    await db
+      .insert(x402PendingTasks)
+      .values({ taskId, paymentRequirements, expiresAt })
+      .onConflictDoUpdate({
+        target: x402PendingTasks.taskId,
+        set: { paymentRequirements, expiresAt },
+      });
+  },
+
+  async getPendingTask(taskId: string): Promise<PaymentRequirements[] | null> {
+    const row = await db.query.x402PendingTasks.findFirst({
+      where: eq(x402PendingTasks.taskId, taskId),
+    });
+    if (!row) return null;
+    if (row.expiresAt < new Date()) {
+      await db.delete(x402PendingTasks).where(eq(x402PendingTasks.taskId, taskId));
+      return null;
+    }
+    return row.paymentRequirements;
+  },
+
+  async deletePendingTask(taskId: string): Promise<void> {
+    await db.delete(x402PendingTasks).where(eq(x402PendingTasks.taskId, taskId));
+  },
+
+  /** Deletes all expired pending tasks. Call periodically to keep the table clean. */
+  async evictStaleTasks(): Promise<void> {
+    await db.delete(x402PendingTasks).where(lt(x402PendingTasks.expiresAt, new Date()));
+  },
+};

--- a/docs/accepts-multi-option-implementation.md
+++ b/docs/accepts-multi-option-implementation.md
@@ -1,0 +1,260 @@
+# x402 `accepts` 다중 결제 옵션 — 구현 분석 및 요구사항 명세
+
+> 기준 스펙: A2A x402 Extension v0.2
+> 작성일: 2026-03-16
+
+---
+
+## 1. 개요
+
+x402 프로토콜에서 Merchant Agent는 단일 결제 수단을 강제하지 않는다. 대신
+`x402PaymentRequiredResponse` 객체 안의 **`accepts` 배열**을 통해 복수의
+`PaymentRequirements` 옵션을 제공하고, Client Agent는 그 중 하나를 선택하여 서명한다.
+
+CLI의 사용자는 Agent이므로, 옵션 선택은 Agent가 직접 수행한다. 이 문서는 표준 스펙의
+데이터 구조와 현재 구현의 차이를 분석하고, 완전한 구현을 위해 필요한 작업을 기술한다.
+
+---
+
+## 2. 표준 스펙 구조 분석
+
+### 2.1 `x402PaymentRequiredResponse`
+
+Merchant가 Client에게 전달하는 최상위 결제 요청 객체다.
+
+```json
+{
+  "x402Version": 1,
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "base",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bda02913",
+      "payTo": "0xMerchantWalletAddress",
+      "maxAmountRequired": "120000000"
+    },
+    {
+      "scheme": "exact",
+      "network": "base-sepolia",
+      "asset": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      "payTo": "0xMerchantWalletAddress",
+      "maxAmountRequired": "120000000"
+    }
+  ]
+}
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| `x402Version` | `number` | 필수 | 프로토콜 버전 (현재 `1`) |
+| `accepts` | `PaymentRequirements[]` | 필수 | Merchant가 수락 가능한 결제 옵션 목록 |
+
+### 2.2 `PaymentRequirements` (단일 옵션)
+
+`accepts` 배열의 각 원소. 현재 `packages/x402/src/index.ts`에 정의된 타입과 동일하다.
+
+```typescript
+interface PaymentRequirements {
+  scheme: string;              // 결제 방식. 현재 "exact"만 지원
+  network: string;             // 블록체인 네트워크 (e.g. "base", "base-sepolia")
+  asset: `0x${string}`;        // ERC-20 토큰 컨트랙트 주소
+  payTo: `0x${string}`;        // 수신 지갑 주소 (Merchant)
+  maxAmountRequired: string;   // 최대 결제 금액 (토큰 최소 단위)
+  maxTimeoutSeconds?: number;  // 서명 유효 시간 (초)
+  resource?: string;           // 결제 대상 리소스 URI
+  description?: string;        // 사람이 읽을 수 있는 설명
+  mimeType?: string;
+  outputSchema?: unknown;
+  estimatedProcessingTime?: number;
+  extra?: Record<string, unknown>; // EIP-712 도메인 메타데이터 등
+}
+```
+
+### 2.3 Standalone Flow에서의 전달 위치
+
+```
+task.status.message.metadata
+  ├── "x402.payment.status": "payment-required"
+  └── "x402.payment.required": x402PaymentRequiredResponse   ← accepts 배열 포함
+```
+
+### 2.4 Embedded Flow (AP2)에서의 전달 위치
+
+```
+task.artifacts[].parts[].data
+  └── "ap2.mandates.CartMandate"
+        └── payment_request.method_data[].data
+              └── x402PaymentRequiredResponse   ← accepts 배열 포함
+```
+
+---
+
+## 3. 현재 구현과 표준의 차이 (Gap Analysis)
+
+### 3.1 `packages/x402` — 타입 누락
+
+**현재 상태:** `PaymentRequirements` 단일 타입만 export됨.
+
+**누락 타입:**
+```typescript
+// 존재하지 않음
+interface X402PaymentRequiredResponse {
+  x402Version: number;
+  accepts: PaymentRequirements[];
+}
+```
+
+**영향:** 이 타입이 없으면 Merchant 구현체와 Client Agent 파싱 로직 모두 자체적으로
+정의해야 하므로 상호운용성이 깨진다.
+
+---
+
+### 3.2 `apps/web` — `/api/x402/sign` 엔드포인트
+
+**현재 상태:**
+```typescript
+// apps/web/src/app/api/x402/sign/route.ts:63-66
+const body = await req.json() as {
+  paymentRequirements?: PaymentRequirements;  // 단일 객체만 수신
+  validForSeconds?: number;
+};
+```
+
+Agent가 `accepts` 배열에서 선택한 하나의 `PaymentRequirements`를 직접 전달하는
+방식이므로 **이 엔드포인트 자체는 변경 불필요하다.**
+
+Agent는 다음 순서로 동작한다:
+1. `x402PaymentRequiredResponse`에서 `accepts` 배열을 수신
+2. Agent가 자체 판단으로 옵션 하나를 선택
+3. 선택한 `PaymentRequirements` 하나를 `/api/x402/sign`에 전달
+4. 서명된 `PaymentPayload`를 수신하여 Merchant에게 제출
+
+---
+
+## 4. 구현 요구사항
+
+### 4.1 `packages/x402` — 타입 추가
+
+#### 4.1.1 `X402PaymentRequiredResponse` 타입 추가
+
+```typescript
+export interface X402PaymentRequiredResponse {
+  x402Version: number;
+  accepts: PaymentRequirements[];
+}
+```
+
+이 타입을 export하면 Agent 구현체와 Merchant 구현체가 공통 타입을 참조할 수 있다.
+
+---
+
+### 4.2 Merchant Agent 측 구현 참고사항
+
+이 저장소는 주로 Client(Agent) 측이지만, `accepts` 배열을 올바르게 구성하는 Merchant
+구현체를 위한 참고 가이드.
+
+#### 4.2.1 `accepts` 배열 구성 원칙
+
+- **mainnet 옵션은 testnet 옵션보다 앞에** 배치한다 (Agent가 별도 선호 로직 없을 때 첫 번째 선택).
+- **같은 네트워크 내에서** USDC를 먼저, 다른 스테이블코인을 뒤에 배치한다.
+- 동일한 `payTo` 주소라도 네트워크별로 별개의 옵션을 제공해야 한다.
+
+```json
+{
+  "x402Version": 1,
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "base",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "payTo": "0xMerchant",
+      "maxAmountRequired": "1000000",
+      "extra": { "name": "USDC", "version": "2" }
+    },
+    {
+      "scheme": "exact",
+      "network": "base-sepolia",
+      "asset": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      "payTo": "0xMerchant",
+      "maxAmountRequired": "1000000",
+      "extra": { "name": "USDC", "version": "2" }
+    }
+  ]
+}
+```
+
+#### 4.2.2 `extra` 필드 활용
+
+EIP-712 서명 시 토큰 컨트랙트의 도메인 메타데이터(`name`, `version`)가 필요하다.
+Merchant는 이를 `extra` 필드에 포함시켜야 Agent가 별도 온체인 조회 없이 서명할 수 있다.
+
+```json
+"extra": {
+  "name": "USDC",
+  "version": "2"
+}
+```
+
+> 현재 `packages/x402`의 `getTokenMetadata()`는 알려진 USDC 주소에 대해서만 자동으로
+> 메타데이터를 반환한다. 커스텀 토큰은 반드시 `extra`를 통해 제공해야 한다.
+
+#### 4.2.3 Merchant의 taskId 기반 상태 관리
+
+Merchant는 `taskId`를 키로 하여 원래 전송한 `accepts` 배열을 저장해야 한다.
+Client Agent로부터 `payment-submitted`를 수신했을 때:
+
+1. `taskId`로 원래 `accepts` 배열 조회
+2. 수신한 `PaymentPayload`의 `(network, asset, payTo, amount)`가 `accepts` 배열의
+   어느 옵션과 일치하는지 확인
+3. 일치하는 옵션으로만 settlement 처리
+
+---
+
+## 5. 타입 정의 전체 요약
+
+`packages/x402/src/index.ts`에 추가되어야 할 타입:
+
+```typescript
+export interface X402PaymentRequiredResponse {
+  x402Version: number;
+  accepts: PaymentRequirements[];
+}
+```
+
+---
+
+## 6. A2A 메타데이터 키 요약
+
+| 키 | 위치 | 값 타입 | 설명 |
+|----|------|---------|------|
+| `x402.payment.status` | `message.metadata` | `string` | 결제 상태 |
+| `x402.payment.required` | `message.metadata` | `X402PaymentRequiredResponse` | Standalone Flow 요청 |
+| `x402.payment.payload` | `message.metadata` | `PaymentPayload` | Standalone Flow 응답 |
+| `x402.payment.receipts` | `message.metadata` | `X402SettleResponse[]` | 정산 결과 |
+| `x402.payment.error` | `message.metadata` | `string` | 에러 코드 |
+
+**`x402.payment.status` 값:**
+
+```
+payment-required → payment-submitted → payment-verified → payment-completed
+                → payment-rejected
+                                                         → payment-failed
+```
+
+---
+
+## 7. 구현 우선순위 및 작업 목록
+
+| 우선순위 | 작업 | 위치 |
+|---------|------|------|
+| P0 | `X402PaymentRequiredResponse` 타입 export | `packages/x402` |
+| P1 | Merchant 측 `accepts` 배열 검증 로직 (taskId 기반) | Merchant 구현체 |
+
+---
+
+## 8. 참고 자료
+
+- [A2A x402 Extension Spec v0.2](../docs/a2a-x402-spec-v0.2.md)
+- [x402 Protocol Specification — Data Types](https://github.com/coinbase/x402?tab=readme-ov-file#data-types)
+- [EIP-3009: Transfer With Authorization](https://eips.ethereum.org/EIPS/eip-3009)
+- [EIP-712: Typed structured data hashing and signing](https://eips.ethereum.org/EIPS/eip-712)


### PR DESCRIPTION
## Changes

Store x402 payment multi-accepts options in the database instead of in-memory or hardcoded values.

### Key Changes
- Add `x402-store.ts` — DB-backed accepts management
- Update `schema.ts` — add accepts table
- Add Drizzle migration `0006`
- Refactor `a2a/route.ts` — read accepts from DB

### Reference
- See `docs/accepts-multi-option-implementation.md` for implementation details