### PR TITLE
feat(web): support x402 multi-accepts payment via A2A_X402_ACCEPTS

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -19,13 +19,15 @@ FAUCET_ADMIN_ADDRESS=
 
 DATABASE_URL=
 
+# x402 payment facilitator endpoint
+X402_FACILITATOR_URL=https://x402.org/facilitator # public testnet facilitator endpoint
+
 # x402 payment extension (Merchant Agent config)
 # A2A_X402_PAY_TO — wallet address that receives payments (required to enable x402 flow)
-# A2A_X402_NETWORK — blockchain network (default: base-sepolia)
-# A2A_X402_ASSET   — ERC-20 token contract address (default: USDC on the selected network)
-# A2A_X402_MAX_AMOUNT — required payment amount in token base units (default: 1000000 = 1 USDC)
+# A2A_X402_ACCEPTS — JSON array of accepted payment options (network/asset/maxAmount per entry).
+#   Each entry: { "network": "<network>", "asset": "<token-address>", "maxAmount": "<amount-in-base-units>" }
+#   Example (two networks):
+#     A2A_X402_ACCEPTS=[{"network":"base-sepolia","asset":"0x036CbD53842c5426634e7929541eC2318f3dCF7e","maxAmount":"1000"},{"network":"base","asset":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","maxAmount":"1000"}]
+
 A2A_X402_PAY_TO=
-A2A_X402_NETWORK=base-sepolia
-A2A_X402_ASSET=0x036CbD53842c5426634e7929541eC2318f3dCF7e # USDC on base-sepolia
-A2A_X402_MAX_AMOUNT=1000 # 0.001 USDC
-X402_FACILITATOR_URL=https://x402.org/facilitator # public testnet facilitator endpoint
+A2A_X402_ACCEPTS=

--- a/apps/web/fly.toml.example
+++ b/apps/web/fly.toml.example
@@ -16,13 +16,16 @@ primary_region = 'nrt'
 [env]
   PORT = '3000'
   APP_URL = 'set-your-domain'
-
-  # x402 payment extension (Merchant Agent config)
-  A2A_X402_PAY_TO=''
-  A2A_X402_NETWORK = 'base-sepolia'
-  A2A_X402_ASSET = '0x036CbD53842c5426634e7929541eC2318f3dCF7e'
-  A2A_X402_MAX_AMOUNT = '1000'
   X402_FACILITATOR_URL = 'https://x402.org/facilitator'
+  # x402 payment extension (Merchant Agent config)
+  # A2A_X402_PAY_TO  — wallet address that receives payments (required to enable x402 flow)
+  # A2A_X402_ACCEPTS — JSON array of accepted payment options.
+  #   Each entry: {"network":"<network>","asset":"<token-address>","maxAmount":"<amount-in-base-units>"}
+  #   Example (single entry): [{"network":"base-sepolia","asset":"0x036CbD53842c5426634e7929541eC2318f3dCF7e","maxAmount":"1000"}]
+  #   If omitted, x402 payment is disabled.
+  A2A_X402_PAY_TO = ''
+  A2A_X402_ACCEPTS = ''
+
 
 [http_service]
   internal_port = 3000

--- a/apps/web/src/app/api/a2a/route.ts
+++ b/apps/web/src/app/api/a2a/route.ts
@@ -1,211 +1,13 @@
 import { randomUUID } from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { a2aDeviceStore } from '@/lib/a2a-device-store';
+import { X402Facilitator, type PaymentPayload } from '@a2a-x402-wallet/x402';
 import {
-  NETWORKS,
-  type NetworkName,
-  type PaymentPayload,
-  type PaymentRequirements,
-} from '@a2a-x402-wallet/x402';
-
-// ---------------------------------------------------------------------------
-// Facilitator — direct HTTP calls (no @x402/core library)
-// ---------------------------------------------------------------------------
-const FACILITATOR_URL = process.env.X402_FACILITATOR_URL ?? 'https://x402.org/facilitator';
-
-async function verifyPayment(
-  payload: PaymentPayload,
-  requirements: PaymentRequirements,
-): Promise<{ valid: boolean; reason?: string; payer?: string }> {
-  let response: Response;
-  try {
-    response = await fetch(`${FACILITATOR_URL}/verify`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ x402Version: 1, paymentPayload: payload, paymentRequirements: requirements }),
-    });
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return { valid: false, reason: `facilitator_unreachable: ${msg}` };
-  }
-
-  const data = await response.json() as {
-    isValid: boolean;
-    invalidReason?: string;
-    payer?: string;
-  };
-
-  if (!response.ok) return { valid: false, reason: data.invalidReason ?? `http_${response.status}` };
-  return { valid: data.isValid, reason: data.invalidReason, payer: data.payer };
-}
-
-async function settlePayment(
-  payload: PaymentPayload,
-  requirements: PaymentRequirements,
-): Promise<{ success: boolean; transaction: string; network: string; payer?: string; errorReason?: string }> {
-  let response: Response;
-  try {
-    response = await fetch(`${FACILITATOR_URL}/settle`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ x402Version: 1, paymentPayload: payload, paymentRequirements: requirements }),
-    });
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return { success: false, transaction: '', network: requirements.network, errorReason: `facilitator_unreachable: ${msg}` };
-  }
-
-  const data = await response.json() as {
-    success: boolean;
-    transaction: string;
-    network: string;
-    payer?: string;
-    errorReason?: string;
-  };
-
-  if (!response.ok || !data.success) {
-    return { success: false, transaction: data.transaction ?? '', network: data.network ?? requirements.network, payer: data.payer, errorReason: data.errorReason ?? `http_${response.status}` };
-  }
-  return { success: true, transaction: data.transaction, network: data.network, payer: data.payer };
-}
-
-// ---------------------------------------------------------------------------
-// In-memory task store for pending x402 payment tasks.
-// Maps taskId → PaymentRequirements that were issued for that task.
-// ---------------------------------------------------------------------------
-interface PendingPaymentTask {
-  paymentRequirements: PaymentRequirements[];
-  createdAt: number;
-}
-
-const pendingTasks = new Map<string, PendingPaymentTask>();
-
-// Clean up tasks older than 30 minutes
-const TASK_TTL_MS = 30 * 60 * 1000;
-function evictStaleTasks() {
-  const cutoff = Date.now() - TASK_TTL_MS;
-  for (const [id, task] of pendingTasks) {
-    if (task.createdAt < cutoff) pendingTasks.delete(id);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Helpers to build x402-compliant task responses
-// ---------------------------------------------------------------------------
-
-function makePaymentRequiredTask(taskId: string, requirements: PaymentRequirements[]) {
-  return {
-    kind:   'task',
-    id:     taskId,
-    status: {
-      state:   'input-required',
-      message: {
-        kind:  'message',
-        role:  'agent',
-        parts: [{ kind: 'text', text: 'Payment is required to use this service.' }],
-        metadata: {
-          'x402.payment.status':   'payment-required',
-          'x402.payment.required': {
-            x402Version: 1,
-            accepts:     requirements,
-          },
-        },
-      },
-      timestamp: new Date().toISOString(),
-    },
-  };
-}
-
-function makePaymentCompletedTask(taskId: string, network: string, transaction: string) {
-  return {
-    kind:   'task',
-    id:     taskId,
-    status: {
-      state:   'completed',
-      message: {
-        kind:  'message',
-        role:  'agent',
-        parts: [{ kind: 'text', text: 'Payment received. Service request completed.' }],
-        metadata: {
-          'x402.payment.status':   'payment-completed',
-          'x402.payment.receipts': [
-            {
-              success: true,
-              transaction,
-              network,
-            },
-          ],
-        },
-      },
-      timestamp: new Date().toISOString(),
-    },
-    artifacts: [
-      {
-        artifactId: randomUUID(),
-        name:       'result',
-        parts:      [{ kind: 'text', text: 'Echo: payment accepted.' }],
-      },
-    ],
-  };
-}
-
-function makePaymentFailedTask(taskId: string, reason: string, errorCode: string, network: string) {
-  return {
-    kind:   'task',
-    id:     taskId,
-    status: {
-      state:   'failed',
-      message: {
-        kind:  'message',
-        role:  'agent',
-        parts: [{ kind: 'text', text: `Payment failed: ${reason}` }],
-        metadata: {
-          'x402.payment.status': 'payment-failed',
-          'x402.payment.error':  errorCode,
-          'x402.payment.receipts': [
-            {
-              success:     false,
-              errorReason: reason,
-              network,
-              transaction: '',
-            },
-          ],
-        },
-      },
-      timestamp: new Date().toISOString(),
-    },
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Payment requirements from environment
-// ---------------------------------------------------------------------------
-
-function getPaymentRequirements(): PaymentRequirements | null {
-  const payTo = process.env.A2A_X402_PAY_TO as `0x${string}` | undefined;
-  if (!payTo) return null;
-
-  const network    = (process.env.A2A_X402_NETWORK ?? 'base-sepolia') as NetworkName;
-  const networkCfg = NETWORKS[network];
-  const asset      = (process.env.A2A_X402_ASSET ?? networkCfg?.usdcAddress) as `0x${string}`;
-  const maxAmount  = process.env.A2A_X402_MAX_AMOUNT ?? '1000'; // 0.001 USDC
-
-  return {
-    scheme:             'exact',
-    network,
-    asset,
-    payTo,
-    maxAmountRequired:  maxAmount,
-    extra: {
-      name:    networkCfg?.usdcEip712.name    ?? 'USDC',
-      version: networkCfg?.usdcEip712.version ?? '2',
-    },
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Route handler
-// ---------------------------------------------------------------------------
+  getBaseFeePaymentRequirements,
+  makePaymentRequiredTask,
+  makePaymentCompletedTask,
+  makePaymentFailedTask,
+} from '@/lib/x402-payment';
 
 export async function POST(req: NextRequest) {
   const authHeader = req.headers.get('authorization');
@@ -231,8 +33,6 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'invalid_request' }, { status: 400 });
   }
 
-  evictStaleTasks();
-
   const rpcId = body.id ?? null;
 
   // -------------------------------------------------------------------------
@@ -250,68 +50,71 @@ export async function POST(req: NextRequest) {
 
     // --- Step 3: Client submits signed PaymentPayload ---
     if (paymentStatus === 'payment-submitted') {
-      const taskId  = msg?.taskId ?? '';
+      const taskId  = msg?.taskId ?? randomUUID();
       const payload = msg?.metadata?.['x402.payment.payload'] as PaymentPayload | undefined;
-
-      const pending = taskId ? pendingTasks.get(taskId) : undefined;
-      const network = pending?.paymentRequirements[0]?.network ?? 'base-sepolia';
 
       if (!payload) {
         return NextResponse.json({
           jsonrpc: '2.0', id: rpcId,
-          result: makePaymentFailedTask(taskId, 'Missing x402.payment.payload in metadata', 'INVALID_SIGNATURE', network),
+          result: makePaymentFailedTask(taskId, 'Missing x402.payment.payload in metadata', 'INVALID_SIGNATURE', 'unknown'),
         });
       }
 
-      if (!pending) {
+      const { to } = payload.payload.authorization;
+      const requirements = getBaseFeePaymentRequirements();
+      const candidates = requirements.filter(r =>
+        r.network === payload.network &&
+        r.maxAmountRequired === payload.payload.authorization.value &&
+        r.payTo.toLowerCase() === to.toLowerCase()
+      );
+
+      if (candidates.length === 0) {
         return NextResponse.json({
           jsonrpc: '2.0', id: rpcId,
-          result: makePaymentFailedTask(taskId, 'Unknown or expired task', 'EXPIRED_PAYMENT', network),
+          result: makePaymentFailedTask(
+            taskId,
+            `No matching payment requirement for network=${payload.network}, value=${payload.payload.authorization.value.toString()}, to=${to}`,
+            'INVALID_SIGNATURE',
+            payload.network,
+          ),
         });
       }
 
-      const req0 = pending.paymentRequirements[0];
+      const facilitator = new X402Facilitator(
+        process.env.X402_FACILITATOR_URL ?? 'https://x402.org/facilitator',
+      );
 
-      // Verify: signature, amount, recipient, time window (via official facilitator)
-      const verifyResult = await verifyPayment(payload, req0);
+      let matchedReq = candidates[0];
+      let verifyResult = await facilitator.verify(payload, matchedReq);
+      for (let i = 1; !verifyResult.valid && i < candidates.length; i++) {
+        matchedReq = candidates[i];
+        verifyResult = await facilitator.verify(payload, matchedReq);
+      }
+
       if (!verifyResult.valid) {
         return NextResponse.json({
           jsonrpc: '2.0', id: rpcId,
-          result: makePaymentFailedTask(
-            taskId,
-            verifyResult.reason ?? 'Verification failed',
-            verifyResult.reason ?? 'unexpected_verify_error',
-            network,
-          ),
+          result: makePaymentFailedTask(taskId, verifyResult.reason ?? 'Verification failed', 'VERIFICATION_FAILED', payload.network),
         });
       }
 
-      // Settle: submit on-chain transferWithAuthorization, wait for receipt
-      const settleResult = await settlePayment(payload, req0);
+      const settleResult = await facilitator.settle(payload, matchedReq);
       if (!settleResult.success) {
         return NextResponse.json({
           jsonrpc: '2.0', id: rpcId,
-          result: makePaymentFailedTask(
-            taskId,
-            settleResult.errorReason ?? 'Settlement failed',
-            settleResult.errorReason ?? 'unexpected_settle_error',
-            network,
-          ),
+          result: makePaymentFailedTask(taskId, settleResult.errorReason ?? 'Settlement failed', 'SETTLEMENT_FAILED', payload.network),
         });
       }
 
-      pendingTasks.delete(taskId);
-
       return NextResponse.json({
         jsonrpc: '2.0', id: rpcId,
-        result: makePaymentCompletedTask(taskId, network, settleResult.transaction),
+        result: makePaymentCompletedTask(taskId, matchedReq.network, settleResult.transaction),
       });
     }
 
     // --- Client explicitly rejects payment ---
     if (paymentStatus === 'payment-rejected') {
       const taskId = msg?.taskId ?? randomUUID();
-      pendingTasks.delete(taskId);
 
       return NextResponse.json({
         jsonrpc: '2.0', id: rpcId,
@@ -333,18 +136,13 @@ export async function POST(req: NextRequest) {
     }
 
     // --- Step 1: New service request — require payment if configured ---
-    const requirements = getPaymentRequirements();
+    const requirements = getBaseFeePaymentRequirements();
     const taskId = randomUUID();
 
-    if (requirements) {
-      pendingTasks.set(taskId, {
-        paymentRequirements: [requirements],
-        createdAt: Date.now(),
-      });
-
+    if (requirements.length > 0) {
       return NextResponse.json({
         jsonrpc: '2.0', id: rpcId,
-        result: makePaymentRequiredTask(taskId, [requirements]),
+        result: makePaymentRequiredTask(taskId, requirements),
       });
     }
 
@@ -370,22 +168,18 @@ export async function POST(req: NextRequest) {
   }
 
   // -------------------------------------------------------------------------
-  // tasks/get
+  // tasks/get — stub: no persistent task store, return unknown state
   // -------------------------------------------------------------------------
   if (body.method === 'tasks/get') {
     const taskId = (body.params?.id as string | undefined) ?? 'unknown';
-    const pending = pendingTasks.get(taskId);
-
-    if (pending) {
-      return NextResponse.json({
-        jsonrpc: '2.0', id: rpcId,
-        result: makePaymentRequiredTask(taskId, pending.paymentRequirements),
-      });
-    }
 
     return NextResponse.json({
       jsonrpc: '2.0', id: rpcId,
-      error: { code: -32001, message: 'Task not found' },
+      result: {
+        kind:   'task',
+        id:     taskId,
+        status: { state: 'unknown', timestamp: new Date().toISOString() },
+      },
     });
   }
 
@@ -394,7 +188,6 @@ export async function POST(req: NextRequest) {
   // -------------------------------------------------------------------------
   if (body.method === 'tasks/cancel') {
     const taskId = (body.params?.id as string | undefined) ?? 'unknown';
-    pendingTasks.delete(taskId);
 
     return NextResponse.json({
       jsonrpc: '2.0', id: rpcId,

--- a/apps/web/src/lib/x402-payment.ts
+++ b/apps/web/src/lib/x402-payment.ts
@@ -1,0 +1,122 @@
+import { randomUUID } from 'crypto';
+import { NETWORKS, type NetworkName, type PaymentRequirements } from '@a2a-x402-wallet/x402';
+
+// ---------------------------------------------------------------------------
+// Payment requirements from environment
+// ---------------------------------------------------------------------------
+
+interface AcceptsEntry {
+  network:   string;
+  asset:     string;
+  maxAmount: string;
+}
+
+export function getBaseFeePaymentRequirements(): PaymentRequirements[] {
+  const payTo = process.env.A2A_X402_PAY_TO as `0x${string}` | undefined;
+  if (!payTo) return [];
+
+  const acceptsRaw = process.env.A2A_X402_ACCEPTS;
+  if (!acceptsRaw) return [];
+
+  let entries: AcceptsEntry[];
+  try {
+    entries = JSON.parse(acceptsRaw) as AcceptsEntry[];
+  } catch {
+    console.error('[x402] Failed to parse A2A_X402_ACCEPTS JSON:', acceptsRaw);
+    return [];
+  }
+
+  return entries.map((entry) => {
+    const network    = entry.network as NetworkName;
+    const networkCfg = NETWORKS[network];
+    return {
+      scheme: 'exact',
+      network,
+      maxAmountRequired: entry.maxAmount,
+      asset: entry.asset as `0x${string}`,
+      payTo,
+      resource: 'baseFee',
+      mimeType: 'application/json',
+      maxTimeoutSeconds: 0,
+      extra: {
+        name:    networkCfg?.usdcEip712.name    ?? 'USDC',
+        version: networkCfg?.usdcEip712.version ?? '2',
+      },
+    } satisfies PaymentRequirements;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// A2A task response builders (x402 metadata convention)
+// ---------------------------------------------------------------------------
+
+export function makePaymentRequiredTask(taskId: string, requirements: PaymentRequirements[]) {
+  return {
+    kind:   'task',
+    id:     taskId,
+    status: {
+      state:   'input-required',
+      message: {
+        kind:  'message',
+        role:  'agent',
+        parts: [{ kind: 'text', text: 'Payment is required to use this service.' }],
+        metadata: {
+          'x402.payment.status':   'payment-required',
+          'x402.payment.required': {
+            x402Version: 1,
+            accepts:     requirements,
+          },
+        },
+      },
+      timestamp: new Date().toISOString(),
+    },
+  };
+}
+
+export function makePaymentCompletedTask(taskId: string, network: string, transaction: string) {
+  return {
+    kind:   'task',
+    id:     taskId,
+    status: {
+      state:   'completed',
+      message: {
+        kind:  'message',
+        role:  'agent',
+        parts: [{ kind: 'text', text: 'Payment received. Service request completed.' }],
+        metadata: {
+          'x402.payment.status':   'payment-completed',
+          'x402.payment.receipts': [{ success: true, transaction, network }],
+        },
+      },
+      timestamp: new Date().toISOString(),
+    },
+    artifacts: [
+      {
+        artifactId: randomUUID(),
+        name:       'result',
+        parts:      [{ kind: 'text', text: 'Echo: payment accepted.' }],
+      },
+    ],
+  };
+}
+
+export function makePaymentFailedTask(taskId: string, reason: string, errorCode: string, network: string) {
+  return {
+    kind:   'task',
+    id:     taskId,
+    status: {
+      state:   'failed',
+      message: {
+        kind:  'message',
+        role:  'agent',
+        parts: [{ kind: 'text', text: `Payment failed: ${reason}` }],
+        metadata: {
+          'x402.payment.status': 'payment-failed',
+          'x402.payment.error':  errorCode,
+          'x402.payment.receipts': [{ success: false, errorReason: reason, network, transaction: '' }],
+        },
+      },
+      timestamp: new Date().toISOString(),
+    },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "packages:build": "pnpm --filter @a2a-x402-wallet/x402 build",
     "web:dev": "pnpm --filter a2a-x402-wallet-web dev",
     "web:build": "pnpm --filter a2a-x402-wallet-web build",
     "web:start": "pnpm --filter a2a-x402-wallet-web start",

--- a/packages/x402/package.json
+++ b/packages/x402/package.json
@@ -16,6 +16,7 @@
     "build": "tsc"
   },
   "devDependencies": {
+    "@types/node": "^20.19.35",
     "typescript": "^5"
   }
 }

--- a/packages/x402/src/facilitator.ts
+++ b/packages/x402/src/facilitator.ts
@@ -1,0 +1,71 @@
+import type { PaymentPayload, PaymentRequirements } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Facilitator client
+// ---------------------------------------------------------------------------
+
+export class X402Facilitator {
+  constructor(private readonly url: string) {}
+
+  async verify(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<{ valid: boolean; reason?: string; payer?: string }> {
+    let response: Response;
+    try {
+      response = await fetch(`${this.url}/verify`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ x402Version: 1, paymentPayload: payload, paymentRequirements: requirements }),
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { valid: false, reason: `facilitator_unreachable: ${msg}` };
+    }
+
+    const data = await response.json() as {
+      isValid: boolean;
+      invalidReason?: string;
+      payer?: string;
+    };
+
+    if (!response.ok) return { valid: false, reason: data.invalidReason ?? `http_${response.status}` };
+    return { valid: data.isValid, reason: data.invalidReason, payer: data.payer };
+  }
+
+  async settle(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<{ success: boolean; transaction: string; network: string; payer?: string; errorReason?: string }> {
+    let response: Response;
+    try {
+      response = await fetch(`${this.url}/settle`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ x402Version: 1, paymentPayload: payload, paymentRequirements: requirements }),
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { success: false, transaction: '', network: requirements.network, errorReason: `facilitator_unreachable: ${msg}` };
+    }
+
+    const data = await response.json() as {
+      success: boolean;
+      transaction: string;
+      network: string;
+      payer?: string;
+      errorReason?: string;
+    };
+
+    if (!response.ok || !data.success) {
+      return {
+        success: false,
+        transaction: data.transaction ?? '',
+        network: data.network ?? requirements.network,
+        payer: data.payer,
+        errorReason: data.errorReason ?? `http_${response.status}`,
+      };
+    }
+    return { success: true, transaction: data.transaction, network: data.network, payer: data.payer };
+  }
+}

--- a/packages/x402/src/index.ts
+++ b/packages/x402/src/index.ts
@@ -1,49 +1,15 @@
-// x402 Protocol Types and Utilities
+export type {
+  PaymentRequirements,
+  TransferWithAuthorizationPayload,
+  ExactSchemePayload,
+  PaymentPayload,
+  NetworkName,
+  NetworkConfig,
+} from './types.js';
 
-export interface PaymentRequirements {
-  scheme: string;
-  network: string;
-  asset: `0x${string}`;
-  payTo: `0x${string}`;
-  maxAmountRequired: string;
-  maxTimeoutSeconds?: number;
-  resource?: string;
-  description?: string;
-  mimeType?: string;
-  outputSchema?: unknown;
-  estimatedProcessingTime?: number;
-  extra?: Record<string, unknown>;
-}
+import type { NetworkName, NetworkConfig, TransferWithAuthorizationPayload } from './types.js';
 
-export interface TransferWithAuthorizationPayload {
-  from: `0x${string}`;
-  to: `0x${string}`;
-  value: string;
-  validAfter: string;
-  validBefore: string;
-  nonce: `0x${string}`;
-}
-
-export interface ExactSchemePayload {
-  signature: `0x${string}`;
-  authorization: TransferWithAuthorizationPayload;
-}
-
-export interface PaymentPayload {
-  x402Version: number;
-  scheme: string;
-  network: string;
-  payload: ExactSchemePayload;
-}
-
-// Supported network names
-export type NetworkName = 'base' | 'base-sepolia';
-
-export interface NetworkConfig {
-  chainId: number;
-  usdcAddress: `0x${string}`;
-  usdcEip712: { name: string; version: string };
-}
+export { X402Facilitator } from './facilitator.js';
 
 export const NETWORKS: Record<NetworkName, NetworkConfig> = {
   'base': {

--- a/packages/x402/src/types.ts
+++ b/packages/x402/src/types.ts
@@ -1,0 +1,43 @@
+export interface PaymentRequirements {
+  scheme: string;
+  network: string;
+  asset: `0x${string}`;
+  payTo: `0x${string}`;
+  maxAmountRequired: string;
+  maxTimeoutSeconds?: number;
+  resource?: string;
+  description?: string;
+  mimeType?: string;
+  outputSchema?: unknown;
+  estimatedProcessingTime?: number;
+  extra?: Record<string, unknown>;
+}
+
+export interface TransferWithAuthorizationPayload {
+  from: `0x${string}`;
+  to: `0x${string}`;
+  value: string;
+  validAfter: string;
+  validBefore: string;
+  nonce: `0x${string}`;
+}
+
+export interface ExactSchemePayload {
+  signature: `0x${string}`;
+  authorization: TransferWithAuthorizationPayload;
+}
+
+export interface PaymentPayload {
+  x402Version: number;
+  scheme: string;
+  network: string;
+  payload: ExactSchemePayload;
+}
+
+export type NetworkName = 'base' | 'base-sepolia';
+
+export interface NetworkConfig {
+  chainId: number;
+  usdcAddress: `0x${string}`;
+  usdcEip712: { name: string; version: string };
+}

--- a/packages/x402/tsconfig.json
+++ b/packages/x402/tsconfig.json
@@ -8,7 +8,8 @@
     "outDir": "./dist",
     "declaration": true,
     "isolatedModules": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["node_modules"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
 
   packages/x402:
     devDependencies:
+      '@types/node':
+        specifier: ^20.19.35
+        version: 20.19.35
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -940,89 +943,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1190,24 +1209,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.6':
     resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.6':
     resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
@@ -1515,66 +1538,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -2105,24 +2141,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
@@ -2338,41 +2378,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3989,24 +4037,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}


### PR DESCRIPTION
### Summary
- Replace individual `A2A_X402_NETWORK` / `A2A_X402_ASSET` / `A2A_X402_MAX_AMOUNT` env vars with a single `A2A_X402_ACCEPTS` JSON array to support multiple network/token payment options
- Extract `X402Facilitator` class into the `@a2a-x402-wallet/x402` shared package for reusability
- Remove in-memory `pendingTasks` store in favor of stateless payment matching based on payload content
### Motivation
Previously only a single network/token could be configured as a payment option. By replacing it with an `A2A_X402_ACCEPTS` JSON array, merchant agents can now accept payments on multiple chains simultaneously (e.g. Base Mainnet and Base Sepolia).
### Changes
- `packages/x402/src/types.ts`: Extract all type definitions into a dedicated file
- `packages/x402/src/facilitator.ts`: Add `X402Facilitator` class with `verify` and `settle` methods
- `packages/x402/src/index.ts`: Refactor to re-export from types and facilitator modules
- `apps/web/src/lib/x402-payment.ts`: Extract `getBaseFeePaymentRequirements` and `makePayment*Task` helpers out of the route handler
- `apps/web/src/app/api/a2a/route.ts`: Drastically simplified by removing in-memory task store and using the new shared modules
- `.env.example`, `fly.toml.example`: Update configuration docs to reflect new `A2A_X402_ACCEPTS` array format
