### PR TITLE
feat(a2a): upgrade @a2a-js/sdk to 0.3.13 and align types

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -17,7 +17,7 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@a2a-js/sdk": "^0.3.10",
+    "@a2a-js/sdk": "^0.3.13",
     "@a2a-x402-wallet/x402": "workspace:*",
     "@scure/bip32": "^1.6.2",
     "@scure/bip39": "^1.5.4",

--- a/apps/cli/src/commands/a2a/client.ts
+++ b/apps/cli/src/commands/a2a/client.ts
@@ -1,3 +1,4 @@
+import { HTTP_EXTENSION_HEADER } from '@a2a-js/sdk';
 import { ClientFactory, ClientFactoryOptions, JsonRpcTransportFactory, RestTransportFactory } from '@a2a-js/sdk/client';
 
 const X402_EXTENSION_URI = 'https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2';
@@ -9,20 +10,10 @@ const X402_EXTENSION_URI = 'https://github.com/google-agentic-commerce/a2a-x402/
 export function buildClientFactory(bearer?: string): ClientFactory {
   const baseFetch: typeof fetch = (input, init) => {
     const headers = new Headers(init?.headers);
-    headers.set('X-A2A-Extensions', X402_EXTENSION_URI);
+    headers.set(HTTP_EXTENSION_HEADER, X402_EXTENSION_URI);
     if (bearer) headers.set('Authorization', `Bearer ${bearer}`);
     return fetch(input, { ...init, headers });
   };
-
-  if (!bearer) {
-    const options = ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
-      transports: [
-        new JsonRpcTransportFactory({ fetchImpl: baseFetch }),
-        new RestTransportFactory({ fetchImpl: baseFetch }),
-      ],
-    });
-    return new ClientFactory(options);
-  }
 
   const options = ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
     transports: [

--- a/apps/cli/src/services/a2a.ts
+++ b/apps/cli/src/services/a2a.ts
@@ -1,3 +1,4 @@
+import type { AgentCard, OAuth2SecurityScheme } from '@a2a-js/sdk';
 import { DefaultAgentCardResolver } from '@a2a-js/sdk/client';
 
 export interface DeviceCodeFlow {
@@ -5,21 +6,29 @@ export interface DeviceCodeFlow {
   tokenUrl: string;
 }
 
-export async function fetchAgentCard(url: string): Promise<unknown> {
+export async function fetchAgentCard(url: string): Promise<AgentCard> {
   const resolver = new DefaultAgentCardResolver();
   return resolver.resolve(url);
 }
 
-export function findDeviceCodeFlow(card: unknown): DeviceCodeFlow | null {
-  const schemes = (card as Record<string, unknown>)?.securitySchemes;
-  if (!schemes || typeof schemes !== 'object') return null;
+export function findDeviceCodeFlow(card: AgentCard): DeviceCodeFlow | null {
+  const { security, securitySchemes } = card;
+  if (!security || !securitySchemes) return null;
 
-  for (const scheme of Object.values(schemes)) {
-    const flow = (scheme as Record<string, unknown>)?.oauth2SecurityScheme as
-      | Record<string, unknown>
-      | undefined;
-    const deviceCode = flow?.flows as Record<string, unknown> | undefined;
-    const dc = deviceCode?.deviceCode as Record<string, unknown> | undefined;
+  // security is an OR-of-ANDs list: each object is a set of scheme names that
+  // must all be satisfied together. Collect the union of all referenced scheme names.
+  const referencedSchemeNames = new Set(
+    security.flatMap((requirement) => Object.keys(requirement)),
+  );
+
+  for (const name of referencedSchemeNames) {
+    const scheme = securitySchemes[name];
+    if (!scheme || scheme.type !== 'oauth2') continue;
+
+    // deviceCode is a non-standard extension to OAuthFlows (A2A spec §4.5.10,
+    // not yet implemented in @a2a-js/sdk)
+    const flows = (scheme as OAuth2SecurityScheme).flows as Record<string, unknown>;
+    const dc = flows.deviceCode as { deviceAuthorizationUrl?: string; tokenUrl?: string } | undefined;
     if (typeof dc?.deviceAuthorizationUrl === 'string' && typeof dc?.tokenUrl === 'string') {
       return {
         deviceAuthorizationUrl: dc.deviceAuthorizationUrl,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "db:migrate": "drizzle-kit migrate"
   },
   "dependencies": {
+    "@a2a-js/sdk": "^0.3.13",
     "@a2a-x402-wallet/x402": "workspace:*",
     "@pothos/core": "^4.12.0",
     "@privy-io/react-auth": "^3.15.0",

--- a/apps/web/src/app/.well-known/agent.json/route.ts
+++ b/apps/web/src/app/.well-known/agent.json/route.ts
@@ -1,3 +1,4 @@
+import type { AgentCard, OAuth2SecurityScheme, OAuthFlows } from '@a2a-js/sdk';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(req: NextRequest) {
@@ -5,10 +6,14 @@ export async function GET(req: NextRequest) {
   const proto = req.headers.get('x-forwarded-proto') ?? req.nextUrl.protocol.replace(':', '');
   const baseUrl = process.env.APP_URL ?? `${proto}://${host}`;
 
-  const card = {
-    name:    'a2a-wallet',
-    url:     `${baseUrl}/api/a2a`,
-    version: '1.0.0',
+  const card: AgentCard = {
+    name:            'a2a-wallet',
+    description:     'A2A-compatible wallet agent supporting x402 on-chain payment settlement.',
+    url:             `${baseUrl}/api/a2a`,
+    version:         '1.0.0',
+    protocolVersion: '1.0',
+    defaultInputModes:  ['text/plain'],
+    defaultOutputModes: ['text/plain'],
     capabilities: {
       extensions: [
         {
@@ -18,21 +23,21 @@ export async function GET(req: NextRequest) {
         },
       ],
     },
+    skills: [],
     securitySchemes: {
       deviceFlow: {
-        oauth2SecurityScheme: {
-          flows: {
-            deviceCode: {
-              deviceAuthorizationUrl: `${baseUrl}/a2a/device/start`,
-              tokenUrl:               `${baseUrl}/a2a/device/token`,
-              scopes:                 {},
-            },
+        type: 'oauth2',
+        flows: {
+          deviceCode: {
+            deviceAuthorizationUrl: `${baseUrl}/a2a/device/start`,
+            tokenUrl:               `${baseUrl}/a2a/device/token`,
+            scopes:                 {},
           },
-        },
-      },
+        } as OAuthFlows,
+      } as OAuth2SecurityScheme,
     },
-    securityRequirements: [{ deviceFlow: [] }],
-  };
+    security: [{ deviceFlow: [] }],
+  } as AgentCard;
 
   return NextResponse.json(card);
 }

--- a/apps/web/src/app/api/a2a/route.ts
+++ b/apps/web/src/app/api/a2a/route.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
+import type { Task, MessageSendParams } from '@a2a-js/sdk';
 import { a2aDeviceStore } from '@/lib/a2a-device-store';
 import { X402Facilitator, type PaymentPayload } from '@a2a-x402-wallet/x402';
 import {
@@ -39,13 +40,8 @@ export async function POST(req: NextRequest) {
   // message/send — primary A2A method, implements x402 Standalone Flow
   // -------------------------------------------------------------------------
   if (body.method === 'message/send') {
-    const params = body.params ?? {};
-    const msg = params.message as {
-      taskId?:   string;
-      parts?:    { kind?: string; text?: string }[];
-      metadata?: Record<string, unknown>;
-    } | undefined;
-
+    const params = body.params as MessageSendParams | undefined;
+    const msg = params?.message;
     const paymentStatus = msg?.metadata?.['x402.payment.status'] as string | undefined;
 
     // --- Step 3: Client submits signed PaymentPayload ---
@@ -115,24 +111,23 @@ export async function POST(req: NextRequest) {
     // --- Client explicitly rejects payment ---
     if (paymentStatus === 'payment-rejected') {
       const taskId = msg?.taskId ?? randomUUID();
-
-      return NextResponse.json({
-        jsonrpc: '2.0', id: rpcId,
-        result: {
-          kind:   'task',
-          id:     taskId,
-          status: {
-            state:   'canceled',
-            message: {
-              kind:  'message',
-              role:  'agent',
-              parts: [{ kind: 'text', text: 'Payment rejected by client. Task canceled.' }],
-              metadata: { 'x402.payment.status': 'payment-rejected' },
-            },
-            timestamp: new Date().toISOString(),
+      const task: Task = {
+        kind:      'task',
+        id:        taskId,
+        contextId: taskId,
+        status: {
+          state:   'canceled',
+          message: {
+            kind:      'message',
+            messageId: randomUUID(),
+            role:      'agent',
+            parts:     [{ kind: 'text', text: 'Payment rejected by client. Task canceled.' }],
+            metadata:  { 'x402.payment.status': 'payment-rejected' },
           },
+          timestamp: new Date().toISOString(),
         },
-      });
+      };
+      return NextResponse.json({ jsonrpc: '2.0', id: rpcId, result: task });
     }
 
     // --- Step 1: New service request — require payment if configured ---
@@ -148,23 +143,23 @@ export async function POST(req: NextRequest) {
 
     // No payment configured — echo response (development fallback)
     const parts = msg?.parts ?? [];
-    const text  = parts.map((p) => p.text ?? '').join(' ').trim() || '(empty)';
-    return NextResponse.json({
-      jsonrpc: '2.0', id: rpcId,
-      result: {
-        kind:   'task',
-        id:     taskId,
-        status: {
-          state:   'completed',
-          message: {
-            kind:  'message',
-            role:  'agent',
-            parts: [{ kind: 'text', text: `Echo: ${text}` }],
-          },
-          timestamp: new Date().toISOString(),
+    const text  = parts.map((p) => p.kind === 'text' ? p.text : '').join(' ').trim() || '(empty)';
+    const task: Task = {
+      kind:      'task',
+      id:        taskId,
+      contextId: taskId,
+      status: {
+        state:   'completed',
+        message: {
+          kind:      'message',
+          messageId: randomUUID(),
+          role:      'agent',
+          parts:     [{ kind: 'text', text: `Echo: ${text}` }],
         },
+        timestamp: new Date().toISOString(),
       },
-    });
+    };
+    return NextResponse.json({ jsonrpc: '2.0', id: rpcId, result: task });
   }
 
   // -------------------------------------------------------------------------
@@ -172,15 +167,13 @@ export async function POST(req: NextRequest) {
   // -------------------------------------------------------------------------
   if (body.method === 'tasks/get') {
     const taskId = (body.params?.id as string | undefined) ?? 'unknown';
-
-    return NextResponse.json({
-      jsonrpc: '2.0', id: rpcId,
-      result: {
-        kind:   'task',
-        id:     taskId,
-        status: { state: 'unknown', timestamp: new Date().toISOString() },
-      },
-    });
+    const task: Task = {
+      kind:      'task',
+      id:        taskId,
+      contextId: taskId,
+      status:    { state: 'unknown', timestamp: new Date().toISOString() },
+    };
+    return NextResponse.json({ jsonrpc: '2.0', id: rpcId, result: task });
   }
 
   // -------------------------------------------------------------------------
@@ -188,15 +181,22 @@ export async function POST(req: NextRequest) {
   // -------------------------------------------------------------------------
   if (body.method === 'tasks/cancel') {
     const taskId = (body.params?.id as string | undefined) ?? 'unknown';
-
-    return NextResponse.json({
-      jsonrpc: '2.0', id: rpcId,
-      result: {
-        kind:   'task',
-        id:     taskId,
-        status: { state: 'canceled', timestamp: new Date().toISOString() },
+    const task: Task = {
+      kind:      'task',
+      id:        taskId,
+      contextId: taskId,
+      status: {
+        state:   'canceled',
+        message: {
+          kind:      'message',
+          messageId: randomUUID(),
+          role:      'agent',
+          parts:     [{ kind: 'text', text: 'Task canceled.' }],
+        },
+        timestamp: new Date().toISOString(),
       },
-    });
+    };
+    return NextResponse.json({ jsonrpc: '2.0', id: rpcId, result: task });
   }
 
   return NextResponse.json({

--- a/apps/web/src/lib/x402-payment.ts
+++ b/apps/web/src/lib/x402-payment.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import type { Task } from '@a2a-js/sdk';
 import { NETWORKS, type NetworkName, type PaymentRequirements } from '@a2a-x402-wallet/x402';
 
 // ---------------------------------------------------------------------------
@@ -50,16 +51,18 @@ export function getBaseFeePaymentRequirements(): PaymentRequirements[] {
 // A2A task response builders (x402 metadata convention)
 // ---------------------------------------------------------------------------
 
-export function makePaymentRequiredTask(taskId: string, requirements: PaymentRequirements[]) {
+export function makePaymentRequiredTask(taskId: string, requirements: PaymentRequirements[]): Task {
   return {
-    kind:   'task',
-    id:     taskId,
+    kind:      'task',
+    id:        taskId,
+    contextId: taskId,
     status: {
       state:   'input-required',
       message: {
-        kind:  'message',
-        role:  'agent',
-        parts: [{ kind: 'text', text: 'Payment is required to use this service.' }],
+        kind:      'message',
+        messageId: randomUUID(),
+        role:      'agent',
+        parts:     [{ kind: 'text', text: 'Payment is required to use this service.' }],
         metadata: {
           'x402.payment.status':   'payment-required',
           'x402.payment.required': {
@@ -73,16 +76,18 @@ export function makePaymentRequiredTask(taskId: string, requirements: PaymentReq
   };
 }
 
-export function makePaymentCompletedTask(taskId: string, network: string, transaction: string) {
+export function makePaymentCompletedTask(taskId: string, network: string, transaction: string): Task {
   return {
-    kind:   'task',
-    id:     taskId,
+    kind:      'task',
+    id:        taskId,
+    contextId: taskId,
     status: {
       state:   'completed',
       message: {
-        kind:  'message',
-        role:  'agent',
-        parts: [{ kind: 'text', text: 'Payment received. Service request completed.' }],
+        kind:      'message',
+        messageId: randomUUID(),
+        role:      'agent',
+        parts:     [{ kind: 'text', text: 'Payment received. Service request completed.' }],
         metadata: {
           'x402.payment.status':   'payment-completed',
           'x402.payment.receipts': [{ success: true, transaction, network }],
@@ -100,16 +105,18 @@ export function makePaymentCompletedTask(taskId: string, network: string, transa
   };
 }
 
-export function makePaymentFailedTask(taskId: string, reason: string, errorCode: string, network: string) {
+export function makePaymentFailedTask(taskId: string, reason: string, errorCode: string, network: string): Task {
   return {
-    kind:   'task',
-    id:     taskId,
+    kind:      'task',
+    id:        taskId,
+    contextId: taskId,
     status: {
       state:   'failed',
       message: {
-        kind:  'message',
-        role:  'agent',
-        parts: [{ kind: 'text', text: `Payment failed: ${reason}` }],
+        kind:      'message',
+        messageId: randomUUID(),
+        role:      'agent',
+        parts:     [{ kind: 'text', text: `Payment failed: ${reason}` }],
         metadata: {
           'x402.payment.status': 'payment-failed',
           'x402.payment.error':  errorCode,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
   apps/cli:
     dependencies:
       '@a2a-js/sdk':
-        specifier: ^0.3.10
-        version: 0.3.10
+        specifier: ^0.3.13
+        version: 0.3.13
       '@a2a-x402-wallet/x402':
         specifier: workspace:*
         version: link:../../packages/x402
@@ -41,6 +41,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@a2a-js/sdk':
+        specifier: ^0.3.13
+        version: 0.3.13
       '@a2a-x402-wallet/x402':
         specifier: workspace:*
         version: link:../../packages/x402
@@ -129,8 +132,8 @@ importers:
 
 packages:
 
-  '@a2a-js/sdk@0.3.10':
-    resolution: {integrity: sha512-t6w5ctnwJkSOMRl6M9rn95C1FTHCPqixxMR0yWXtzhZXEnF6mF1NAK0CfKlG3cz+tcwTxkmn287QZC3t9XPgrA==}
+  '@a2a-js/sdk@0.3.13':
+    resolution: {integrity: sha512-BZr0f9JVNQs3GKOM9xINWCh6OKIJWZFPyqqVqTym5mxO2Eemc6I/0zL7zWnljHzGdaf5aZQyQN5xa6PSH62q+A==}
     engines: {node: '>=18'}
     peerDependencies:
       '@bufbuild/protobuf': ^2.10.2
@@ -5566,7 +5569,7 @@ packages:
 
 snapshots:
 
-  '@a2a-js/sdk@0.3.10':
+  '@a2a-js/sdk@0.3.13':
     dependencies:
       uuid: 11.1.0
 
@@ -5708,7 +5711,7 @@ snapshots:
       idb-keyval: 6.2.1
       ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
-      viem: 2.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      viem: 2.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
       zustand: 5.0.3(@types/react@19.2.14)(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
     transitivePeerDependencies:
       - '@types/react'
@@ -5774,7 +5777,7 @@ snapshots:
       idb-keyval: 6.2.1
       ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
-      viem: 2.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      viem: 2.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
       zustand: 5.0.3(@types/react@19.2.14)(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
     transitivePeerDependencies:
       - '@types/react'
@@ -6933,7 +6936,7 @@ snapshots:
     dependencies:
       big.js: 6.2.2
       dayjs: 1.11.13
-      viem: 2.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      viem: 2.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -6968,7 +6971,7 @@ snapshots:
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.3)
-      viem: 2.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      viem: 2.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -7266,7 +7269,7 @@ snapshots:
       '@walletconnect/logger': 2.1.2
       '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.3)
-      viem: 2.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      viem: 2.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -7370,7 +7373,7 @@ snapshots:
       '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.3)
-      viem: 2.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      viem: 2.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -7536,7 +7539,7 @@ snapshots:
   '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.23.1
-      viem: 2.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@3.25.76)
+      viem: 2.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - typescript


### PR DESCRIPTION
### Summary
- Upgrade `@a2a-js/sdk` from `0.3.10` to `0.3.13` in CLI and add it as an explicit dependency in the web app
- Replace ad-hoc inline type casts with SDK-exported types (`Task`, `AgentCard`, `MessageSendParams`, `OAuth2SecurityScheme`) across server routes and task builder helpers
- Align `AgentCard` shape and security scheme structure with the updated SDK spec (`security` / `securitySchemes`, direct `type: 'oauth2'` instead of nested `oauth2SecurityScheme`)
### Motivation
`@a2a-js/sdk` 0.3.13 ships renamed fields and refined type exports that were previously cast as `unknown` or constructed with plain object literals. Aligning to the new SDK types removes fragile casts, improves compile-time safety, and keeps the agent card response spec-compliant.
### Changes
- `apps/cli/package.json`: bump `@a2a-js/sdk` to `^0.3.13`
- `apps/cli/src/commands/a2a/client.ts`: use `HTTP_EXTENSION_HEADER` constant; remove duplicate bearer-less factory branch
- `apps/cli/src/services/a2a.ts`: type `fetchAgentCard` return as `AgentCard`; rewrite `findDeviceCodeFlow` to use `security`/`securitySchemes` fields and `OAuth2SecurityScheme` type
- `apps/web/package.json`: add `@a2a-js/sdk ^0.3.13` as explicit dependency
- `apps/web/src/app/.well-known/agent.json/route.ts`: type card as `AgentCard`; rename `securityRequirements` → `security`; restructure OAuth2 scheme to `{ type: 'oauth2', flows }` shape; add `protocolVersion`, `description`, `defaultInputModes/OutputModes`, `skills`
- `apps/web/src/app/api/a2a/route.ts`: use `Task` and `MessageSendParams` types; add `contextId` and `messageId` to all task/message objects
- `apps/web/src/lib/x402-payment.ts`: annotate all three builder functions with `Task` return type; add `contextId` and `messageId` fields
