### PR TITLE
feat(cli): add --allow-x402 flag and accept agentCardUrl directly in agent commands

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -495,15 +495,17 @@ a2a-wallet a2a disconnect <url>
 
 ### `a2a card`
 
-Fetches and displays an agent's AgentCard from `/.well-known/agent.json`.
+Fetches and displays an agent's AgentCard.
 
 ```bash
-a2a-wallet a2a card <url> [--path <path>] [--json]
+a2a-wallet a2a card <url|agentCardUrl> [--path <path>] [--json]
 ```
+
+`<url|agentCardUrl>` accepts either an agent base URL or an agent card URL (e.g. `agentCardUrl` from `registry search`).
 
 | Option | Description |
 |--------|-------------|
-| `--path <path>` | Custom agent card path (default: `/.well-known/agent.json`) |
+| `--path <path>` | Custom agent card path — overrides the auto-detected path (default: `/.well-known/agent-card.json`) |
 | `--json` | Output raw JSON (single line) |
 
 ### `a2a send`
@@ -511,8 +513,10 @@ a2a-wallet a2a card <url> [--path <path>] [--json]
 Sends a message to an A2A agent and prints the full response.
 
 ```bash
-a2a-wallet a2a send <url> <message> [options]
+a2a-wallet a2a send <url|agentCardUrl> <message> [options]
 ```
+
+`<url|agentCardUrl>` accepts either an agent base URL or an agent card URL (e.g. `agentCardUrl` from `registry search`).
 
 | Option | Description |
 |--------|-------------|
@@ -529,8 +533,10 @@ a2a-wallet a2a send <url> <message> [options]
 Sends a message to an A2A agent and streams the response via SSE. Text parts are written to stdout as they arrive; other events (task, status-update, artifact-update) are printed as pretty JSON.
 
 ```bash
-a2a-wallet a2a stream <url> <message> [options]
+a2a-wallet a2a stream <url|agentCardUrl> <message> [options]
 ```
+
+`<url|agentCardUrl>` accepts either an agent base URL or an agent card URL (e.g. `agentCardUrl` from `registry search`).
 
 | Option | Description |
 |--------|-------------|
@@ -545,8 +551,10 @@ a2a-wallet a2a stream <url> <message> [options]
 Retrieves the current state of a task.
 
 ```bash
-a2a-wallet a2a tasks get <url> <taskId> [options]
+a2a-wallet a2a tasks get <url|agentCardUrl> <taskId> [options]
 ```
+
+`<url|agentCardUrl>` accepts either an agent base URL or an agent card URL (e.g. `agentCardUrl` from `registry search`).
 
 | Option | Description |
 |--------|-------------|
@@ -559,8 +567,10 @@ a2a-wallet a2a tasks get <url> <taskId> [options]
 Requests cancellation of a running task.
 
 ```bash
-a2a-wallet a2a cancel <url> <taskId> [options]
+a2a-wallet a2a cancel <url|agentCardUrl> <taskId> [options]
 ```
+
+`<url|agentCardUrl>` accepts either an agent base URL or an agent card URL (e.g. `agentCardUrl` from `registry search`).
 
 | Option | Description |
 |--------|-------------|
@@ -590,8 +600,8 @@ $ a2a-wallet registry search "usdc payment"
 
 name              description                                       agent_card_url
 ----------------  ------------------------------------------------  -------------------------------------------
-x402-pay-agent    Handles x402 micropayment flows automatically…    https://pay.example.com/.well-known/agent.json
-wallet-assistant  Signs and submits USDC transfers on Base…         https://wallet.agent.xyz/.well-known/agent.json
+x402-pay-agent    Handles x402 micropayment flows automatically…    https://pay.example.com/.well-known/agent-card.json
+wallet-assistant  Signs and submits USDC transfers on Base…         https://wallet.agent.xyz/.well-known/agent-card.json
 ```
 
 **Output example (`--json`):**
@@ -601,7 +611,7 @@ wallet-assistant  Signs and submits USDC transfers on Base…         https://wa
   {
     "name": "x402-pay-agent",
     "description": "Handles x402 micropayment flows automatically",
-    "agentCardUrl": "https://pay.example.com/.well-known/agent.json"
+    "agentCardUrl": "https://pay.example.com/.well-known/agent-card.json"
   }
 ]
 ```
@@ -629,7 +639,7 @@ a2a-wallet registry register <agent-card-url> [options]
 **Example:**
 
 ```
-$ a2a-wallet registry register https://my-agent.example.com/.well-known/agent.json
+$ a2a-wallet registry register https://my-agent.example.com/.well-known/agent-card.json
 Agent registered successfully.
 ```
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -521,6 +521,7 @@ a2a-wallet a2a send <url> <message> [options]
 | `--metadata <json>` | JSON metadata to attach to the message (e.g. x402 payment payload) |
 | `--bearer <token>` | Bearer token for agent authentication |
 | `--file <path\|uri>` | Attach a file to the message (repeatable). Local path → base64-embedded; `http(s)://` URI → referenced by URL |
+| `--allow-x402` | Automatically sign and submit x402 payment if the agent responds with a payment-required request |
 | `--json` | Output raw JSON (single line) |
 
 ### `a2a stream`
@@ -536,6 +537,7 @@ a2a-wallet a2a stream <url> <message> [options]
 | `--context-id <id>` | Continue an existing conversation context |
 | `--bearer <token>` | Bearer token for agent authentication |
 | `--file <path\|uri>` | Attach a file to the message (repeatable). Local path → base64-embedded; `http(s)://` URI → referenced by URL |
+| `--allow-x402` | Automatically sign and submit x402 payment if the agent responds with a payment-required request |
 | `--json` | Output each event as raw JSON (one line per event) |
 
 ### `a2a tasks get`

--- a/apps/cli/src/commands/a2a/cancel.ts
+++ b/apps/cli/src/commands/a2a/cancel.ts
@@ -1,11 +1,11 @@
 import { Command } from 'commander';
-import { buildClientFactory, formatA2AError } from './client.js';
+import { buildClientFactory, formatA2AError, resolveAgentCardArgs } from './client.js';
 import { getConnection } from '../../store/config.js';
 
 export function makeCancelCommand(): Command {
   return new Command('cancel')
     .description('Request cancellation of a running task.\nThe agent may or may not honor the request depending on its current state.')
-    .argument('<url>', 'Agent base URL (e.g. https://my-agent.example.com)')
+    .argument('<url|agentCardUrl>', 'Agent base URL or agent card URL (e.g. from registry search)')
     .argument('<taskId>', 'Task ID to cancel')
     .option('--bearer <token>', 'Bearer token for agent authentication')
     .option('--json', 'Output raw JSON (single line)')
@@ -13,7 +13,7 @@ export function makeCancelCommand(): Command {
       const bearer = opts.bearer ?? getConnection(url)?.apiKey;
       const factory = buildClientFactory(bearer);
       try {
-        const client = await factory.createFromUrl(url);
+        const client = await factory.createFromUrl(...resolveAgentCardArgs(url));
         const task = await client.cancelTask({ id: taskId });
 
         if (opts.json) {

--- a/apps/cli/src/commands/a2a/card.ts
+++ b/apps/cli/src/commands/a2a/card.ts
@@ -1,16 +1,18 @@
 import { Command } from 'commander';
 import { DefaultAgentCardResolver } from '@a2a-js/sdk/client';
+import { resolveAgentCardArgs } from './client.js';
 
 export function makeCardCommand(): Command {
   return new Command('card')
-    .description("Fetch and display an agent's AgentCard from /.well-known/agent.json.\nShows the agent's name, capabilities, skills, and supported extensions.")
-    .argument('<url>', 'Agent base URL (e.g. https://my-agent.example.com)')
-    .option('--path <path>', 'Custom agent card path (default: /.well-known/agent.json)')
+    .description("Fetch and display an agent's AgentCard from /.well-known/agent-card.json.\nShows the agent's name, capabilities, skills, and supported extensions.")
+    .argument('<url|agentCardUrl>', 'Agent base URL or agent card URL (e.g. from registry search)')
+    .option('--path <path>', 'Custom agent card path (default: /.well-known/agent-card.json)')
     .option('--json', 'Output raw JSON (single line)')
     .action(async (url: string, opts: { path?: string; json?: boolean }) => {
       const resolver = new DefaultAgentCardResolver();
       try {
-        const card = await resolver.resolve(url, opts.path);
+        const [resolvedUrl, resolvedPath] = resolveAgentCardArgs(url);
+        const card = await resolver.resolve(resolvedUrl, opts.path ?? resolvedPath);
         if (opts.json) {
           console.log(JSON.stringify(card));
         } else {

--- a/apps/cli/src/commands/a2a/client.ts
+++ b/apps/cli/src/commands/a2a/client.ts
@@ -4,6 +4,15 @@ import { ClientFactory, ClientFactoryOptions, JsonRpcTransportFactory, RestTrans
 const X402_EXTENSION_URI = 'https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.2';
 
 /**
+ * Resolve createFromUrl args from a URL that may be either a base URL or a full agent card URL.
+ * If the URL ends with .json, treat it as the full card URL (path='').
+ * Otherwise, let the SDK append the default /.well-known/agent-card.json.
+ */
+export function resolveAgentCardArgs(url: string): [string, string | undefined] {
+  return url.endsWith('.json') ? [url, ''] : [url, undefined];
+}
+
+/**
  * Build a ClientFactory with an optional Bearer token injected into every request.
  * Always includes the X-A2A-Extensions header per the x402 spec (Section 8).
  */

--- a/apps/cli/src/commands/a2a/send.ts
+++ b/apps/cli/src/commands/a2a/send.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { randomUUID } from 'crypto';
-import { buildClientFactory, formatA2AError, bytesReplacer } from './client.js';
+import { buildClientFactory, formatA2AError, bytesReplacer, resolveAgentCardArgs } from './client.js';
 import { getConnection } from '../../store/config.js';
 import { readFileAsBytes, parseFileUri } from '../../lib/file.js';
 import { resolveSigner } from '../../wallet/signer.js';
@@ -11,7 +11,7 @@ import type { FilePart } from '@a2a-js/sdk';
 export function makeSendCommand(): Command {
   return new Command('send')
     .description('Send a text message to an agent and wait for the response.\nSupports multi-turn conversations (--context-id) and x402 payment payloads (--metadata).')
-    .argument('<url>', 'Agent base URL (e.g. https://my-agent.example.com)')
+    .argument('<url|agentCardUrl>', 'Agent base URL or agent card URL (e.g. from registry search)')
     .argument('<message>', 'Text message to send')
     .option('--context-id <id>', 'Continue an existing conversation context')
     .option('--task-id <id>', 'Task ID to send message to (for payment or multi-turn)')
@@ -20,7 +20,19 @@ export function makeSendCommand(): Command {
     .option('--file <path|uri>', 'Attach a file to the message (repeatable)', (v: string, acc: string[]) => [...acc, v], [] as string[])
     .option('--allow-x402', 'Automatically sign and submit x402 payment if the agent responds with a payment-required request')
     .option('--json', 'Output raw JSON (single line)')
-    .action(async (url: string, message: string, opts: { contextId?: string; taskId?: string; metadata?: string; bearer?: string; file: string[]; allowX402?: boolean; json?: boolean }) => {
+    .action(async (
+      url: string,
+      message: string,
+      opts: {
+        contextId?: string;
+        taskId?: string;
+        metadata?: string;
+        bearer?: string;
+        file: string[];
+        allowX402?: boolean;
+        json?: boolean
+      }
+    ) => {
       const bearer = opts.bearer ?? getConnection(url)?.apiKey;
       const factory = buildClientFactory(bearer);
 
@@ -49,7 +61,7 @@ export function makeSendCommand(): Command {
       }
 
       try {
-        const client = await factory.createFromUrl(url);
+        const client = await factory.createFromUrl(...resolveAgentCardArgs(url));
         let response = await client.sendMessage({
           message: {
             kind: 'message',

--- a/apps/cli/src/commands/a2a/send.ts
+++ b/apps/cli/src/commands/a2a/send.ts
@@ -3,6 +3,8 @@ import { randomUUID } from 'crypto';
 import { buildClientFactory, formatA2AError, bytesReplacer } from './client.js';
 import { getConnection } from '../../store/config.js';
 import { readFileAsBytes, parseFileUri } from '../../lib/file.js';
+import { resolveSigner } from '../../wallet/signer.js';
+import { getX402PaymentInfo } from './x402-handler.js';
 import type { FilePart } from '@a2a-js/sdk';
 
 
@@ -16,8 +18,9 @@ export function makeSendCommand(): Command {
     .option('--metadata <json>', 'JSON metadata to attach to the message (e.g. x402 payment payload)')
     .option('--bearer <token>', 'Bearer token for agent authentication')
     .option('--file <path|uri>', 'Attach a file to the message (repeatable)', (v: string, acc: string[]) => [...acc, v], [] as string[])
+    .option('--allow-x402', 'Automatically sign and submit x402 payment if the agent responds with a payment-required request')
     .option('--json', 'Output raw JSON (single line)')
-    .action(async (url: string, message: string, opts: { contextId?: string; taskId?: string; metadata?: string; bearer?: string; file: string[]; json?: boolean }) => {
+    .action(async (url: string, message: string, opts: { contextId?: string; taskId?: string; metadata?: string; bearer?: string; file: string[]; allowX402?: boolean; json?: boolean }) => {
       const bearer = opts.bearer ?? getConnection(url)?.apiKey;
       const factory = buildClientFactory(bearer);
 
@@ -47,7 +50,7 @@ export function makeSendCommand(): Command {
 
       try {
         const client = await factory.createFromUrl(url);
-        const response = await client.sendMessage({
+        let response = await client.sendMessage({
           message: {
             kind: 'message',
             messageId: randomUUID(),
@@ -58,6 +61,30 @@ export function makeSendCommand(): Command {
             ...(parsedMetadata ? { metadata: parsedMetadata } : {}),
           },
         });
+
+        if (opts.allowX402) {
+          const paymentInfo = getX402PaymentInfo(response);
+          if (paymentInfo) {
+            console.error('[x402] Payment required. Signing and submitting...');
+            const signer = await resolveSigner();
+            const payload = await signer.signX402Payment(paymentInfo.requirements);
+            response = await client.sendMessage({
+              message: {
+                kind: 'message',
+                messageId: randomUUID(),
+                role: 'user',
+                parts: [{ kind: 'text', text: message }, ...fileParts],
+                taskId: paymentInfo.taskId,
+                ...(paymentInfo.contextId ? { contextId: paymentInfo.contextId } : {}),
+                metadata: {
+                  'x402.payment.status': 'payment-submitted',
+                  'x402.payment.payload': payload,
+                },
+              },
+            });
+            console.error('[x402] Payment submitted.');
+          }
+        }
 
         if (opts.json) {
           console.log(JSON.stringify(response, bytesReplacer));

--- a/apps/cli/src/commands/a2a/stream.ts
+++ b/apps/cli/src/commands/a2a/stream.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { randomUUID } from 'crypto';
-import { buildClientFactory, formatA2AError, bytesReplacer } from './client.js';
+import { buildClientFactory, formatA2AError, bytesReplacer, resolveAgentCardArgs } from './client.js';
 import { getConnection } from '../../store/config.js';
 import { readFileAsBytes, parseFileUri } from '../../lib/file.js';
 import { resolveSigner } from '../../wallet/signer.js';
@@ -10,7 +10,7 @@ import type { FilePart } from '@a2a-js/sdk';
 export function makeStreamCommand(): Command {
   return new Command('stream')
     .description("Send a text message and stream the agent's response in real time via SSE.\nText parts are written to stdout as they arrive; other events are printed as JSON.")
-    .argument('<url>', 'Agent base URL (e.g. https://my-agent.example.com)')
+    .argument('<url|agentCardUrl>', 'Agent base URL or agent card URL (e.g. from registry search)')
     .argument('<message>', 'Text message to send')
     .option('--context-id <id>', 'Continue an existing conversation context')
     .option('--bearer <token>', 'Bearer token for agent authentication')
@@ -50,7 +50,7 @@ export function makeStreamCommand(): Command {
       };
 
       try {
-        const client = await factory.createFromUrl(url);
+        const client = await factory.createFromUrl(...resolveAgentCardArgs(url));
         const stream = client.sendMessageStream({
           message: {
             kind: 'message',

--- a/apps/cli/src/commands/a2a/stream.ts
+++ b/apps/cli/src/commands/a2a/stream.ts
@@ -3,6 +3,8 @@ import { randomUUID } from 'crypto';
 import { buildClientFactory, formatA2AError, bytesReplacer } from './client.js';
 import { getConnection } from '../../store/config.js';
 import { readFileAsBytes, parseFileUri } from '../../lib/file.js';
+import { resolveSigner } from '../../wallet/signer.js';
+import { getX402PaymentInfo } from './x402-handler.js';
 import type { FilePart } from '@a2a-js/sdk';
 
 export function makeStreamCommand(): Command {
@@ -13,8 +15,9 @@ export function makeStreamCommand(): Command {
     .option('--context-id <id>', 'Continue an existing conversation context')
     .option('--bearer <token>', 'Bearer token for agent authentication')
     .option('--file <path|uri>', 'Attach a file to the message (repeatable)', (v: string, acc: string[]) => [...acc, v], [] as string[])
+    .option('--allow-x402', 'Automatically sign and submit x402 payment if the agent responds with a payment-required request')
     .option('--json', 'Output each event as raw JSON (one line per event)')
-    .action(async (url: string, message: string, opts: { contextId?: string; bearer?: string; file: string[]; json?: boolean }) => {
+    .action(async (url: string, message: string, opts: { contextId?: string; bearer?: string; file: string[]; allowX402?: boolean; json?: boolean }) => {
       const bearer = opts.bearer ?? getConnection(url)?.apiKey;
       const factory = buildClientFactory(bearer);
 
@@ -32,6 +35,20 @@ export function makeStreamCommand(): Command {
         }
       }
 
+      const printEvent = (event: unknown) => {
+        if (opts.json) {
+          console.log(JSON.stringify(event, bytesReplacer));
+        } else if (event && typeof event === 'object' && (event as Record<string, unknown>)['kind'] === 'message') {
+          const msg = event as { parts: Array<{ kind: string; text?: string }> };
+          for (const part of msg.parts) {
+            if (part.kind === 'text' && part.text) process.stdout.write(part.text);
+          }
+        } else {
+          // task, status-update, artifact-update 이벤트
+          console.log(JSON.stringify(event, bytesReplacer, 2));
+        }
+      };
+
       try {
         const client = await factory.createFromUrl(url);
         const stream = client.sendMessageStream({
@@ -44,17 +61,38 @@ export function makeStreamCommand(): Command {
           },
         });
 
+        let x402Handled = false;
         for await (const event of stream) {
-          if (opts.json) {
-            console.log(JSON.stringify(event, bytesReplacer));
-          } else if (event.kind === 'message') {
-            for (const part of event.parts) {
-              if (part.kind === 'text') process.stdout.write(part.text);
+          if (opts.allowX402 && !x402Handled) {
+            const paymentInfo = getX402PaymentInfo(event);
+            if (paymentInfo) {
+              x402Handled = true;
+              printEvent(event);
+              console.error('[x402] Payment required. Signing and submitting...');
+              const signer = await resolveSigner();
+              const payload = await signer.signX402Payment(paymentInfo.requirements);
+              console.error('[x402] Payment submitted.');
+              const paymentStream = client.sendMessageStream({
+                message: {
+                  kind: 'message',
+                  messageId: randomUUID(),
+                  role: 'user',
+                  parts: [{ kind: 'text', text: message }],
+                  taskId: paymentInfo.taskId,
+                  ...(paymentInfo.contextId ? { contextId: paymentInfo.contextId } : {}),
+                  metadata: {
+                    'x402.payment.status': 'payment-submitted',
+                    'x402.payment.payload': payload,
+                  },
+                },
+              });
+              for await (const paymentEvent of paymentStream) {
+                printEvent(paymentEvent);
+              }
+              break;
             }
-          } else {
-            // task, status-update, artifact-update 이벤트
-            console.log(JSON.stringify(event, bytesReplacer, 2));
           }
+          printEvent(event);
         }
 
         if (!opts.json) process.stdout.write('\n');

--- a/apps/cli/src/commands/a2a/tasks.ts
+++ b/apps/cli/src/commands/a2a/tasks.ts
@@ -1,11 +1,11 @@
 import { Command } from 'commander';
-import { buildClientFactory, formatA2AError } from './client.js';
+import { buildClientFactory, formatA2AError, resolveAgentCardArgs } from './client.js';
 import { getConnection } from '../../store/config.js';
 
 function makeTasksGetCommand(): Command {
   return new Command('get')
     .description('Fetch the current state and message history of a task by ID.\nUseful for checking the result of a previous send or monitoring an in-progress task.')
-    .argument('<url>', 'Agent base URL (e.g. https://my-agent.example.com)')
+    .argument('<url|agentCardUrl>', 'Agent base URL or agent card URL (e.g. from registry search)')
     .argument('<taskId>', 'Task ID to retrieve')
     .option('--history <n>', 'Include last N messages from task history', '0')
     .option('--bearer <token>', 'Bearer token for agent authentication')
@@ -14,7 +14,7 @@ function makeTasksGetCommand(): Command {
       const bearer = opts.bearer ?? getConnection(url)?.apiKey;
       const factory = buildClientFactory(bearer);
       try {
-        const client = await factory.createFromUrl(url);
+        const client = await factory.createFromUrl(...resolveAgentCardArgs(url));
         const task = await client.getTask({
           id: taskId,
           historyLength: parseInt(opts.history, 10),

--- a/apps/cli/src/commands/a2a/x402-handler.ts
+++ b/apps/cli/src/commands/a2a/x402-handler.ts
@@ -1,0 +1,44 @@
+import type { PaymentRequirements } from '@a2a-x402-wallet/x402';
+
+export interface X402PaymentInfo {
+  taskId: string;
+  contextId?: string;
+  requirements: PaymentRequirements;
+}
+
+/**
+ * Checks if an A2A event is an x402 Standalone Flow payment-required task.
+ * Handles both 'task' and 'status-update' event kinds.
+ * Returns payment info if payment is required, null otherwise.
+ */
+export function getX402PaymentInfo(event: unknown): X402PaymentInfo | null {
+  if (!event || typeof event !== 'object') return null;
+  const e = event as Record<string, unknown>;
+
+  let taskId: string | undefined;
+  let contextId: string | undefined;
+  let status: Record<string, unknown> | undefined;
+
+  if (e['kind'] === 'task') {
+    taskId = e['id'] as string;
+    contextId = e['contextId'] as string | undefined;
+    status = e['status'] as Record<string, unknown> | undefined;
+  } else if (e['kind'] === 'status-update') {
+    taskId = e['taskId'] as string;
+    contextId = e['contextId'] as string | undefined;
+    status = e['status'] as Record<string, unknown> | undefined;
+  } else {
+    return null;
+  }
+
+  if (!taskId || !status || status['state'] !== 'input-required') return null;
+
+  const message = status['message'] as Record<string, unknown> | undefined;
+  const metadata = message?.['metadata'] as Record<string, unknown> | undefined;
+  if (!metadata || metadata['x402.payment.status'] !== 'payment-required') return null;
+
+  const required = metadata['x402.payment.required'] as { x402Version?: number; accepts?: PaymentRequirements[] } | undefined;
+  if (!required?.accepts?.length) return null;
+
+  return { taskId, contextId, requirements: required.accepts[0]! };
+}

--- a/apps/cli/src/commands/registry/register.ts
+++ b/apps/cli/src/commands/registry/register.ts
@@ -5,7 +5,7 @@ import { getRegistryUrl } from '../../store/config.js';
 export function makeRegisterCommand(): Command {
   return new Command('register')
     .description('Register an A2A agent in the agent registry')
-    .argument('<agent-card-url>', 'URL to the agent card (/.well-known/agent.json)')
+    .argument('<agent-card-url>', 'URL to the agent card (/.well-known/agent-card.json)')
     .option('--registry <url>', 'agent-registry base URL')
     .option('--json', 'output raw JSON')
     .action(async (agentCardUrl: string, opts) => {

--- a/skills/a2a-wallet/SKILL.md
+++ b/skills/a2a-wallet/SKILL.md
@@ -89,7 +89,16 @@ Agents declaring this extension monetize their services via on-chain cryptocurre
 }
 ```
 
-**Payment flow**:
+**Payment flow (automatic)**:
+
+Use `--allow-x402` with `send` or `stream` to handle the entire flow automatically — the CLI detects the payment request, signs it, and resubmits without any extra steps:
+
+```bash
+a2a-wallet a2a send --allow-x402 https://my-agent.example.com "Hello"
+a2a-wallet a2a stream --allow-x402 https://my-agent.example.com "Hello"
+```
+
+**Payment flow (manual)**:
 1. Send a message → agent replies with `task.status = input-required` and `metadata["x402.payment.status"] = "payment-required"` plus `metadata["x402.payment.required"]` containing `PaymentRequirements`
 2. Sign the requirements with `x402 sign`:
    ```bash
@@ -195,4 +204,5 @@ a2a-wallet wallet use --custodial   # set custodial as the default
 - Override token/URL per-call with `--token` / `--url`, or set `A2A_WALLET_TOKEN` env var
 - Always run `a2a card <url>` first to check which extensions are required before sending messages
 - Use `--file <path|uri>` with `send` or `stream` to attach files (repeatable). Local path → base64-embedded; `http(s)://` URI → referenced by URL
+- Use `--allow-x402` with `send` or `stream` to automatically handle x402 payment requests without manual signing steps
 - Use `a2a-wallet --help` or `a2a-wallet <command> --help` to discover options at any time

--- a/skills/a2a-wallet/SKILL.md
+++ b/skills/a2a-wallet/SKILL.md
@@ -36,18 +36,20 @@ If a command fails with a "command not found" error, refer to **[INSTALL.md](./I
 
 Use the `registry search` command to discover A2A agents by keyword or capability:
 
-```bash
-a2a-wallet registry search <query>
-```
-
 Examples:
 ```bash
-a2a-wallet registry search "image generation"
-a2a-wallet registry search translator
-a2a-wallet registry search --json weather   # machine-readable output
+a2a-wallet registry search --json "image generation"
 ```
 
-The registry returns matching agents with their name, description, and card URL. Use the card URL with `a2a card <url>` to inspect capabilities before interacting.
+The registry returns matching agents with their name, description, and `agentCardUrl`. You can pass the `agentCardUrl` directly to any agent command — no need to strip the path:
+
+```bash
+# Inspect before interacting
+a2a-wallet a2a card https://my-agent.example.com/.well-known/agent-card.json
+
+# Send a message using the agentCardUrl from registry search
+a2a-wallet a2a send https://my-agent.example.com/.well-known/agent-card.json "Hello"
+```
 
 To register a new agent in the registry:
 ```bash
@@ -56,12 +58,39 @@ a2a-wallet registry register <agent-card-url>
 
 ---
 
+## Sending Messages
+
+```bash
+a2a-wallet a2a send <url|agentCardUrl> "message"     # wait for full response
+a2a-wallet a2a stream <url|agentCardUrl> "message"   # stream response via SSE
+```
+
+`<url|agentCardUrl>` accepts either an agent base URL or an agent card URL (e.g. `agentCardUrl` from `registry search`).
+
+**Options** (`send` and `stream` unless noted):
+
+| Option | Description |
+|--------|-------------|
+| `--context-id <id>` | Continue an existing conversation context (omit to start a new one) |
+| `--task-id <id>` | Target a specific task — required when resuming a paused task or submitting x402 payment (`send` only) |
+| `--metadata <json>` | JSON metadata to attach (e.g. x402 payment payload) (`send` only) |
+| `--file <path\|uri>` | Attach a file; repeatable. Local path → base64-embedded, `http(s)://` → URL reference |
+| `--bearer <token>` | Bearer token for agent authentication |
+| `--allow-x402` | Auto-sign and resubmit if agent responds with payment-required |
+| `--json` | Machine-readable output |
+
+---
+
 ## Agent Card Extensions
 
 Before interacting with an A2A agent, inspect its card to check which extensions are declared:
 
 ```bash
+# Base URL — appends /.well-known/agent-card.json automatically
 a2a-wallet a2a card https://my-agent.example.com
+
+# Full agent card URL (e.g. from registry search) — used as-is
+a2a-wallet a2a card https://my-agent.example.com/.well-known/agent-card.json
 ```
 
 The `capabilities.extensions` array in the card lists supported (and possibly required) extensions. The following extension is relevant to this CLI:
@@ -134,14 +163,7 @@ The local wallet stores the private key as a **plain file on disk** (`~/.a2a-wal
 - **Do NOT import or restore a wallet that holds significant assets** into this CLI.
 - If the key file is read by any unauthorized process or leaks for any reason, **all assets are permanently unrecoverable**. The user bears full responsibility.
 
-### Custodial Wallet Risk
-
-The custodial wallet delegates key management to [Privy](https://privy.io) and the a2a-wallet web service. **This project cannot guarantee custodial wallet security.**
-
-- **Do NOT store significant amounts of assets** in the custodial wallet.
-- Key management is outside the user's direct control. The user bears full responsibility for any loss due to third-party service incidents or misconfigurations.
-
-**Both wallet types are intended for small micro-payments only. Always inform the user of these risks and confirm they accept responsibility before proceeding.**
+**Local wallets are intended for small micro-payments only. Always inform the user of these risks and confirm they accept responsibility before proceeding.**
 
 ### Legal Notice
 
@@ -161,16 +183,12 @@ When setting up a wallet, confirm the user understands and accepts the following
 
 ## Wallet selection
 
-The CLI supports two wallet types:
-
-- **Local wallet** — private key stored locally (`wallet create` / `wallet import`). No login required. **Key is stored as a plain file — use only for small amounts.**
-- **Custodial wallet** — signing delegated to the web service. Requires login via `wallet connect`. **Security depends on a third-party provider — use only for small amounts.**
+The CLI uses **local wallets** — private key stored locally (`wallet create` / `wallet import`). No login required. **Key is stored as a plain file — use only for small amounts.**
 
 Switch the active wallet with:
 
 ```bash
-a2a-wallet wallet use <name>       # set a local wallet as default
-a2a-wallet wallet use --custodial  # switch to the custodial wallet
+a2a-wallet wallet use <name>   # set a local wallet as default
 ```
 
 Check current status at any time:
@@ -179,30 +197,8 @@ Check current status at any time:
 a2a-wallet status
 ```
 
-### Custodial wallet login
-
-```bash
-a2a-wallet wallet connect           # opens browser for login
-a2a-wallet wallet connect --poll <device-code>  # complete login (headless)
-```
-
-### Note for users upgrading from v0.3.3 or earlier
-
-In v0.3.3 and below, the wallet was always managed by the web service (custodial). If you want to continue using that same wallet address after upgrading, you must activate the custodial wallet:
-
-```bash
-a2a-wallet wallet connect           # log in to the web service
-a2a-wallet wallet use --custodial   # set custodial as the default
-```
-
-> **Recommendation**: consider migrating to a local wallet. Local wallets sign entirely offline with no dependency on the web service. To switch, run `wallet create` and use the new address going forward.
-
 ## Agent usage tips
 
 - Use `--json` for machine-readable output
 - Errors → stderr, exit `0` = success, `1` = failure
-- Override token/URL per-call with `--token` / `--url`, or set `A2A_WALLET_TOKEN` env var
-- Always run `a2a card <url>` first to check which extensions are required before sending messages
-- Use `--file <path|uri>` with `send` or `stream` to attach files (repeatable). Local path → base64-embedded; `http(s)://` URI → referenced by URL
-- Use `--allow-x402` with `send` or `stream` to automatically handle x402 payment requests without manual signing steps
 - Use `a2a-wallet --help` or `a2a-wallet <command> --help` to discover options at any time


### PR DESCRIPTION
## Summary

- Add `--allow-x402` flag to `send` and `stream` commands to automatically detect, sign, and resubmit x402 payment-required responses without any manual steps
- Add `resolveAgentCardArgs()` helper so all agent commands (`send`, `stream`, `card`, `tasks get`, `cancel`) accept a full `agentCardUrl` (e.g. from `registry search`) directly — no need to strip the path
- Introduce `x402-handler.ts` with `getX402PaymentInfo()` to parse x402 payment-required events from both `task` and `status-update` event kinds
- Update default agent card path references from `/.well-known/agent.json` to `/.well-known/agent-card.json`
- Remove custodial wallet documentation (local wallet only)
- Update `skills/a2a-wallet/SKILL.md` to reflect new `--allow-x402` usage and `agentCardUrl` support

## Test plan

- [x] `a2a send --allow-x402 <agentCardUrl> "message"` — verify automatic payment signing and resubmission on a payment-required agent
- [x] `a2a stream --allow-x402 <agentCardUrl> "message"` — verify streaming with automatic x402 payment handling
- [x] `a2a card <agentCardUrl>` — verify full agent card URL (`.json` suffix) is used as-is without appending a path
- [x] `a2a send <agentCardUrl> "message"` — verify agentCardUrl works without `--allow-x402`
- [x] `a2a send <baseUrl> "message"` — verify plain base URL still works (backward compat)
- [x] `registry search` → copy `agentCardUrl` → pass directly to `a2a send` — verify end-to-end flow
